### PR TITLE
po: Update Simplified Chinese translation for v14

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: dash-to-panel 12\n"
+"Project-Id-Version: dash-to-panel 14\n"
 "Report-Msgid-Bugs-To: https://github.com/jderose9/dash-to-panel/issues\n"
-"POT-Creation-Date: 2018-02-02 21:18+0800\n"
-"PO-Revision-Date: 2018-02-02 21:34+0800\n"
+"POT-Creation-Date: 2018-04-27 22:46+0800\n"
+"PO-Revision-Date: 2018-04-27 22:56+0800\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <debian-l10n-chinese@lists.debian.org>\n"
 "Language: zh_CN\n"
@@ -17,68 +17,76 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: prefs.js:295
+#: prefs.js:297
 msgid "Running Indicator Options"
 msgstr "运行指示器选项"
 
-#: prefs.js:302 prefs.js:447 prefs.js:499 prefs.js:608 prefs.js:684
-#: prefs.js:753 prefs.js:829 prefs.js:871
+#: prefs.js:304 prefs.js:481 prefs.js:537 prefs.js:613 prefs.js:665
+#: prefs.js:804 prefs.js:880 prefs.js:949 prefs.js:1025 prefs.js:1067
 msgid "Reset to defaults"
 msgstr "恢复默认值"
 
-#: prefs.js:440
-msgid "Show Desktop options"
-msgstr "显示桌面选项"
+#: prefs.js:474
+msgid "Intellihide options"
+msgstr "智能隐藏选项"
 
-#: prefs.js:492
+#: prefs.js:530
+msgid "Show Applications options"
+msgstr "“显示应用程序”选项"
+
+#: prefs.js:606
+msgid "Show Desktop options"
+msgstr "“显示桌面”选项"
+
+#: prefs.js:658
 msgid "Window preview options"
 msgstr "窗口预览选项"
 
-#: prefs.js:601
+#: prefs.js:797
 msgid "Ungrouped application options"
 msgstr "未分组的应用程序选项"
 
-#: prefs.js:677
+#: prefs.js:873
 msgid "Customize middle-click behavior"
 msgstr "自定义中键点击行为"
 
-#: prefs.js:746
+#: prefs.js:942
 msgid "Advanced hotkeys options"
 msgstr "高级热键选项"
 
-#: prefs.js:822
+#: prefs.js:1018
 msgid "Secondary Menu Options"
 msgstr "次级菜单选项"
 
-#: prefs.js:864 Settings.ui.h:113
+#: prefs.js:1060 Settings.ui.h:133
 msgid "Advanced Options"
 msgstr "高级选项"
 
-#: appIcons.js:1179
+#: appIcons.js:1233
 msgid "Show Details"
 msgstr "显示细节"
 
-#: appIcons.js:1198
+#: appIcons.js:1252
 msgid "New Window"
 msgstr "新建窗口"
 
-#: appIcons.js:1198 appIcons.js:1260 appIcons.js:1262 Settings.ui.h:8
+#: appIcons.js:1252 appIcons.js:1314 appIcons.js:1316 Settings.ui.h:8
 msgid "Quit"
 msgstr "退出"
 
-#: appIcons.js:1262
+#: appIcons.js:1316
 msgid "Windows"
 msgstr "窗口"
 
-#: appIcons.js:1421
+#: appIcons.js:1495
 msgid "Dash to Panel Settings"
 msgstr "Dash to Panel 设置"
 
-#: appIcons.js:1428
+#: appIcons.js:1502
 msgid "Restore Windows"
 msgstr "恢复窗口"
 
-#: appIcons.js:1428
+#: appIcons.js:1502
 msgid "Show Desktop"
 msgstr "显示桌面"
 
@@ -149,62 +157,54 @@ msgid "Highlight opacity"
 msgstr "高亮不透明度"
 
 #: Settings.ui.h:18
-msgid "5"
-msgstr "5"
-
-#: Settings.ui.h:19
 msgid "Indicator height (px)"
 msgstr "指示器高度（像素）"
 
-#: Settings.ui.h:20
-msgid "0"
-msgstr "0"
-
-#: Settings.ui.h:21
+#: Settings.ui.h:19
 msgid "Indicator color - Override Theme"
 msgstr "指示器颜色 - 覆盖主题"
 
-#: Settings.ui.h:22
+#: Settings.ui.h:20
 msgid "1 window open (or ungrouped)"
 msgstr "1 窗口开启（或未分组）"
 
-#: Settings.ui.h:23
+#: Settings.ui.h:21
 msgid "Apply to all"
 msgstr "应用至全部"
 
-#: Settings.ui.h:24
+#: Settings.ui.h:22
 msgid "2 windows open"
 msgstr "2 窗口开启"
 
-#: Settings.ui.h:25
+#: Settings.ui.h:23
 msgid "3 windows open"
 msgstr "3 窗口开启"
 
-#: Settings.ui.h:26
+#: Settings.ui.h:24
 msgid "4+ windows open"
 msgstr "4+ 窗口开启"
 
-#: Settings.ui.h:27
+#: Settings.ui.h:25
 msgid "Use different for unfocused"
 msgstr "为未取得焦点的程序使用不同方案"
 
-#: Settings.ui.h:28
+#: Settings.ui.h:26
 msgid "Font size (px) of the application titles (default is 14)"
 msgstr "应用程序标题字体大小（像素）（默认值为 14）"
 
-#: Settings.ui.h:29
+#: Settings.ui.h:27
 msgid "Font color of the application titles"
 msgstr "应用程序标题字体颜色"
 
-#: Settings.ui.h:30
+#: Settings.ui.h:28
 msgid "Maximum width (px) of the application titles (default is 160)"
 msgstr "应用程序最大宽度（像素）（默认值为 160）"
 
-#: Settings.ui.h:31
+#: Settings.ui.h:29
 msgid "Use a fixed width for the application titles"
 msgstr "为应用程序标题使用固定宽度"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:30
 msgid ""
 "The application titles all have the same width, even if their texts are "
 "shorter than the maximum width. The maximum width value is used as the fixed "
@@ -213,19 +213,63 @@ msgstr ""
 "应用程序标题都将使用相同宽度，即使其文本宽度无法达到最大宽度。最大宽度值将被"
 "用于固定宽度值。"
 
-#: Settings.ui.h:33
+#: Settings.ui.h:31
 msgid "Display running indicators on unfocused applications"
 msgstr "在未取得焦点的应用上显示运行指示器"
 
-#: Settings.ui.h:34
+#: Settings.ui.h:32
 msgid "Use the favorite icons as application launchers"
 msgstr "使用收藏的图标作为应用程序启动器"
 
+#: Settings.ui.h:33
+msgid "Only hide the panel when it is obstructed by windows "
+msgstr "仅在面板被窗口阻挡时隐藏"
+
+#: Settings.ui.h:34
+msgid "The panel hides from"
+msgstr "触发面板隐藏的对象"
+
 #: Settings.ui.h:35
+msgid "All windows"
+msgstr "所有窗口"
+
+#: Settings.ui.h:36
+msgid "Focused windows"
+msgstr "获得焦点的窗口"
+
+#: Settings.ui.h:37
+msgid "Maximized windows"
+msgstr "最大化窗口"
+
+#: Settings.ui.h:38
+msgid "Require pressure at the edge of the screen  to reveal the panel"
+msgstr "在屏幕边缘受到一定光标压力时显示面板"
+
+#: Settings.ui.h:39
+msgid "Required pressure threshold (px)"
+msgstr "所需压力阈值（像素）"
+
+#: Settings.ui.h:40
+msgid "Required pressure timeout (ms)"
+msgstr "所需压力超时（毫秒）"
+
+#: Settings.ui.h:41
+msgid "Allow the panel to be revealed while in fullscreen mode"
+msgstr "允许面板在全屏幕模式下显示"
+
+#: Settings.ui.h:42
+msgid "Hide and reveal animation duration (ms)"
+msgstr "隐藏与显示动画持续时间（毫秒）"
+
+#: Settings.ui.h:43
+msgid "Delay before hiding the panel (ms)"
+msgstr "隐藏面板之前的延时（毫秒）"
+
+#: Settings.ui.h:44
 msgid "Preview timeout on icon leave (ms)"
 msgstr "离开图标时的预览延时（毫秒）"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:45
 msgid ""
 "If set too low, the window preview of running applications may seem to close "
 "too quickly when trying to enter the popup. If set too high, the preview may "
@@ -234,115 +278,143 @@ msgstr ""
 "如果设置过低，在尝试进入弹出菜单时正在运行程序的窗口预览可能会关闭得过快。如"
 "果设置过高，在移动至临接图标时预览可能滞留过长时间。"
 
-#: Settings.ui.h:37
+#: Settings.ui.h:46
 msgid "Time (ms) before showing (100 is default)"
 msgstr "显示前的延时（毫秒，默认为 100）"
 
-#: Settings.ui.h:38
+#: Settings.ui.h:47
 msgid "Enable window peeking"
 msgstr "启用窗口概览功能"
 
-#: Settings.ui.h:39
+#: Settings.ui.h:48
 msgid ""
 "When hovering over a window preview for some time, the window gets "
 "distinguished."
 msgstr "在窗口预览上悬浮一定时间后，该窗口将被区别显示。"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:49
 msgid "Enter window peeking mode timeout (ms)"
 msgstr "进入窗口概览模式延时（毫秒）"
 
-#: Settings.ui.h:41
+#: Settings.ui.h:50
 msgid ""
 "Time of inactivity while hovering over a window preview needed to enter the "
 "window peeking mode."
 msgstr "为进入窗口概览模式，需要光标悬浮在预览窗口上不活动的时间。"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:51
 msgid "Window peeking mode opacity"
 msgstr "窗口概览模式不透明度"
 
-#: Settings.ui.h:43
+#: Settings.ui.h:52
 msgid ""
 "All windows except for the peeked one have their opacity set to the same "
 "value."
 msgstr "除正在处于概览状态的窗口外，其它所有窗口的不透明度将被设置为同一个值。"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:53
 msgid "Middle click to close window"
 msgstr "中键点击以关闭窗口"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:54
 msgid "Middle click on the preview to close the window."
 msgstr "在预览内容上中键点击以关闭窗口。"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:55
+msgid "Display window title in previews"
+msgstr "在预览中显示窗口标题"
+
+#: Settings.ui.h:56
+msgid "Width of the window previews (px)"
+msgstr "窗口预览宽度（像素）"
+
+#: Settings.ui.h:57
+msgid "Height of the window previews (px)"
+msgstr "窗口预览高度（像素）"
+
+#: Settings.ui.h:58
+msgid "Padding of the window previews (px)"
+msgstr "窗口预览边缘宽度（像素）"
+
+#: Settings.ui.h:59
 msgid "Super"
 msgstr "Super"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:60
 msgid "Super + Alt"
 msgstr "Super + Alt"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:61
 msgid "Hotkeys prefix"
 msgstr "热键前缀"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:62
 msgid "Hotkeys will either be Super+Number or Super+Alt+Num"
 msgstr "热键可以是 Super+数字 或者 Super+Alt+数字"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:63
 msgid "Never"
 msgstr "从不"
 
-#: Settings.ui.h:51
+#: Settings.ui.h:64
 msgid "Show temporarily"
 msgstr "暂时显示"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:65
 msgid "Always visible"
 msgstr "总是可见"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:66
 msgid "Number overlay"
 msgstr "数字附加显示"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:67
 msgid ""
 "Temporarily show the application numbers over the icons when using the "
 "hotkeys."
 msgstr "使用热键时在应用图标上临时显示其对应数字。"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:68
 msgid "Hide timeout (ms)"
 msgstr "隐藏延时（毫秒）"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:69
 msgid "Shortcut to show the overlay for 2 seconds"
 msgstr "显示两秒钟附加数字的快捷键"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:70
 msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
 msgstr "语法：<Shift>, <Ctrl>, <Alt>, <Super>"
 
-#: Settings.ui.h:58
-msgid "Show Desktop button width (px)"
-msgstr "显示桌面图标宽度（像素）"
+#: Settings.ui.h:71
+msgid "Current Show Applications icon"
+msgstr "当前“显示应用程序”图标"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:72
+msgid "Select a Show Applications image icon"
+msgstr "选择一个“显示应用程序”图标图像"
+
+#: Settings.ui.h:73
+msgid "Custom Show Applications image icon"
+msgstr "自定义“显示应用程序”图标图像"
+
+#: Settings.ui.h:74
+msgid "Show Desktop button width (px)"
+msgstr "“显示桌面”按钮图标宽度（像素）"
+
+#: Settings.ui.h:75
 msgid "Panel screen position"
 msgstr "面板屏幕位置"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:76
 msgid "Bottom"
 msgstr "底部"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:77
 msgid "Top"
 msgstr "顶部"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:78
 msgid ""
 "Panel Size\n"
 "(default is 48)"
@@ -350,7 +422,7 @@ msgstr ""
 "面板大小\n"
 "（默认为 48）"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:80
 msgid ""
 "App Icon Margin\n"
 "(default is 8)"
@@ -358,146 +430,162 @@ msgstr ""
 "应用图标边缘空白\n"
 "（默认为 8）"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:82
+msgid ""
+"App Icon Padding\n"
+"(default is 4)"
+msgstr ""
+"应用图标边缘空白\n"
+"（默认为 4）"
+
+#: Settings.ui.h:84
 msgid "Running indicator position"
 msgstr "运行指示器位置"
 
-#: Settings.ui.h:67
+#: Settings.ui.h:85
 msgid "Running indicator style (Focused app)"
 msgstr "运行指示器风格（取得焦点的应用）"
 
-#: Settings.ui.h:68
+#: Settings.ui.h:86
 msgid "Dots"
 msgstr "点"
 
-#: Settings.ui.h:69
+#: Settings.ui.h:87
 msgid "Squares"
 msgstr "方块"
 
-#: Settings.ui.h:70
+#: Settings.ui.h:88
 msgid "Dashes"
 msgstr "横线"
 
-#: Settings.ui.h:71
+#: Settings.ui.h:89
 msgid "Segmented"
 msgstr "间断线"
 
-#: Settings.ui.h:72
+#: Settings.ui.h:90
 msgid "Solid"
 msgstr "实心"
 
-#: Settings.ui.h:73
+#: Settings.ui.h:91
 msgid "Ciliora"
 msgstr "Ciliora"
 
-#: Settings.ui.h:74
+#: Settings.ui.h:92
 msgid "Metro"
 msgstr "Metro"
 
-#: Settings.ui.h:75
+#: Settings.ui.h:93
 msgid "Running indicator style (Unfocused apps)"
 msgstr "运行指示器风格（未取得焦点的应用）"
 
-#: Settings.ui.h:76
+#: Settings.ui.h:94
 msgid "Clock location"
 msgstr "时钟位置"
 
-#: Settings.ui.h:77
+#: Settings.ui.h:95
 msgid "Natural"
 msgstr "自然"
 
-#: Settings.ui.h:78
+#: Settings.ui.h:96
 msgid "Left of status menu"
 msgstr "状态菜单左侧"
 
-#: Settings.ui.h:79
+#: Settings.ui.h:97
 msgid "Right of status menu"
 msgstr "状态菜单右侧"
 
-#: Settings.ui.h:80
+#: Settings.ui.h:98
 msgid "Taskbar position"
 msgstr "任务栏位置"
 
-#: Settings.ui.h:81
+#: Settings.ui.h:99
 msgid "Left side of panel"
 msgstr "面板左侧"
 
-#: Settings.ui.h:82
+#: Settings.ui.h:100
 msgid "Centered in monitor"
 msgstr "显示器居中"
 
-#: Settings.ui.h:83
+#: Settings.ui.h:101
 msgid "Centered in content"
 msgstr "内容居中"
 
-#: Settings.ui.h:84
+#: Settings.ui.h:102
+msgid "Panel Intellihide"
+msgstr "面板智能隐藏"
+
+#: Settings.ui.h:103
+msgid "Hide and reveal the panel according to preferences"
+msgstr "按照配置隐藏和显示面板"
+
+#: Settings.ui.h:104
 msgid "Position and Style"
 msgstr "位置和风格"
 
-#: Settings.ui.h:85
+#: Settings.ui.h:105
 msgid "Show favorite applications"
 msgstr "显示收藏的应用程序"
 
-#: Settings.ui.h:86
+#: Settings.ui.h:106
 msgid "Show <i>Applications</i> icon"
 msgstr "显示<b>应用</b>图标"
 
-#: Settings.ui.h:87
+#: Settings.ui.h:107
 msgid "Animate <i>Show Applications</i>."
 msgstr "动画化<b>显示应用程序</b>。"
 
-#: Settings.ui.h:88
+#: Settings.ui.h:108
 msgid "Show <i>Activities</i> button"
 msgstr "显示<b>活动</b>按钮"
 
-#: Settings.ui.h:89
+#: Settings.ui.h:109
 msgid "Show <i>Desktop</i> button"
 msgstr "显示<b>桌面</b>按钮"
 
-#: Settings.ui.h:90
+#: Settings.ui.h:110
 msgid "Show <i>AppMenu</i> button"
 msgstr "显示<b>应用菜单</b>按钮"
 
-#: Settings.ui.h:91
+#: Settings.ui.h:111
 msgid "Top Bar > Show App Menu must be enabled in Tweak Tool"
 msgstr "必须在优化工具中启用顶栏 > 显示应用菜单"
 
-#: Settings.ui.h:92
+#: Settings.ui.h:112
 msgid "Show window previews on hover"
 msgstr "悬停时显示窗口预览"
 
-#: Settings.ui.h:93
+#: Settings.ui.h:113
 msgid "Isolate Workspaces"
 msgstr "隔离工作区"
 
-#: Settings.ui.h:94
+#: Settings.ui.h:114
 msgid "Ungroup applications"
 msgstr "取消应用程序分组"
 
-#: Settings.ui.h:95
+#: Settings.ui.h:115
 msgid "Behaviour when clicking on the icon of a running application."
 msgstr "点击正在运行应用程序图标时的行为。"
 
-#: Settings.ui.h:96
+#: Settings.ui.h:116
 msgid "Click action"
 msgstr "点击行为"
 
-#: Settings.ui.h:97
+#: Settings.ui.h:117
 msgid ""
 "Enable Super+(0-9) as shortcuts to activate apps. It can also be used "
 "together with Shift and Ctrl."
 msgstr ""
 "将 Super+(0-9) 作为激活应用程序的快捷键。它也可以和 Shift 或 Ctrl 共同使用。"
 
-#: Settings.ui.h:98
+#: Settings.ui.h:118
 msgid "Use hotkeys to activate apps"
 msgstr "使用热键激活应用"
 
-#: Settings.ui.h:99
+#: Settings.ui.h:119
 msgid "Behavior"
 msgstr "行为"
 
-#: Settings.ui.h:100
+#: Settings.ui.h:120
 msgid ""
 "Tray Font Size\n"
 "(0 = theme default)"
@@ -505,7 +593,7 @@ msgstr ""
 "托盘字体大小\n"
 "（0 = 主题默认）"
 
-#: Settings.ui.h:102
+#: Settings.ui.h:122
 msgid ""
 "LeftBox Font Size\n"
 "(0 = theme default)"
@@ -513,7 +601,7 @@ msgstr ""
 "LeftBox 字体大小\n"
 "（0 = 主题默认）"
 
-#: Settings.ui.h:104
+#: Settings.ui.h:124
 msgid ""
 "Tray Item Padding\n"
 "(-1 = theme default)"
@@ -521,7 +609,7 @@ msgstr ""
 "托盘项边缘空白\n"
 "（-1 = 主题默认）"
 
-#: Settings.ui.h:106
+#: Settings.ui.h:126
 msgid ""
 "Status Icon Padding\n"
 "(-1 = theme default)"
@@ -529,7 +617,7 @@ msgstr ""
 "状态图标边缘空白\n"
 "（-1 = 主题默认）"
 
-#: Settings.ui.h:108
+#: Settings.ui.h:128
 msgid ""
 "LeftBox Padding\n"
 "(-1 = theme default)"
@@ -537,31 +625,31 @@ msgstr ""
 "LeftBox 边缘空白\n"
 "（-1 = 主题默认）"
 
-#: Settings.ui.h:110
+#: Settings.ui.h:130
 msgid "Animate switching applications"
 msgstr "动画切换应用程序"
 
-#: Settings.ui.h:111
+#: Settings.ui.h:131
 msgid "Animate launching new windows"
 msgstr "动画启动新窗口"
 
-#: Settings.ui.h:112
+#: Settings.ui.h:132
 msgid "App icon secondary (right-click) menu"
 msgstr "应用图标次级（右键点击）菜单"
 
-#: Settings.ui.h:114
+#: Settings.ui.h:134
 msgid "Fine-Tune"
 msgstr "微调"
 
-#: Settings.ui.h:115
+#: Settings.ui.h:135
 msgid "version: "
 msgstr "版本："
 
-#: Settings.ui.h:116
+#: Settings.ui.h:136
 msgid "Github"
 msgstr "Github"
 
-#: Settings.ui.h:117
+#: Settings.ui.h:137
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -571,6 +659,12 @@ msgstr ""
 "请查看 <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 "\">GNU 通用公共许可证，第二版或更新版本</a> 以了解详情。</span>"
 
-#: Settings.ui.h:119
+#: Settings.ui.h:139
 msgid "About"
 msgstr "关于"
+
+#~ msgid "5"
+#~ msgstr "5"
+
+#~ msgid "0"
+#~ msgstr "0"


### PR DESCRIPTION
As requested in #385 , this PR would refresh Simplified Chinese translation ( `zh_CN` translation) for v14.