### PR TITLE
don't move when CENTEREDMONITOR

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -394,13 +394,21 @@ var dtpPanel = new Lang.Class({
                 childBox.x1 = 0;
                 childBox.x2 = sideWidth;
             }
+        } else if (taskbarPosition == 'CENTEREDMONITOR' ) {
+            if (this.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
+                childBox.x1 = allocWidth - Math.min(Math.floor(sideWidth), leftNaturalWidth);
+                childBox.x2 = allocWidth;
+            } else {
+                childBox.x1 = 0;
+                childBox.x2 = Math.min(Math.floor(sideWidth), leftNaturalWidth);
+            }
         } else {
             if (this.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
                 childBox.x1 = allocWidth - leftNaturalWidth;
                 childBox.x2 = allocWidth;
             } else {
                 childBox.x1 = 0;
-                childBox.x2 =leftNaturalWidth;
+                childBox.x2 = leftNaturalWidth;
             }
         }
         this.panel._leftBox.allocate(childBox, flags, true);
@@ -413,6 +421,14 @@ var dtpPanel = new Lang.Class({
                 childBox.x2 = childBox.x1 + centerNaturalWidth;
             } else {
                 childBox.x1 = allocWidth - centerNaturalWidth - rightNaturalWidth;
+                childBox.x2 = childBox.x1 + centerNaturalWidth;
+            }
+        } else if (taskbarPosition == 'CENTEREDMONITOR' ) {
+            if (this.panel.actor.get_text_direction() == Clutter.TextDirection.RTL) {
+                childBox.x1 = Math.ceil(sideWidth);
+                childBox.x2 = childBox.x1 + centerNaturalWidth;
+            } else {
+                childBox.x1 = allocWidth - centerNaturalWidth - Math.ceil(sideWidth);
                 childBox.x2 = childBox.x1 + centerNaturalWidth;
             }
         } else {


### PR DESCRIPTION
Hello,

Because I'm using both _Dash to Panel_ and _No Title Bar_, I can have very long leftBox while I'm in CENTEREDMONITOR option. So, when it's so long, when leftBox reaches centerBox, the centerBox is moved to the right to let leftBox occupies all the space it want to. My centerBox, with my dash in panel, can even be hidden by the rightBox.

To avoid this, I fix centerBox in its place when CENTEREDMONITOR option is checked.

Before:
 ![capture du 2018-05-08 16-31-06](https://user-images.githubusercontent.com/20989929/39763427-54e1aac8-52dd-11e8-8685-0ad0647640ab.png)


After:
![capture du 2018-05-08 16-26-45](https://user-images.githubusercontent.com/20989929/39763426-5488f798-52dd-11e8-8889-2d04914c6eba.png)