### PR TITLE
Allow changing of font weight of ungrouped application titles.

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1038,6 +1038,55 @@
               </object>
             </child>
             <child>
+              <object class="GtkListBoxRow" id="listbox_group_apps_label_font_weight">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_group_apps_label_font_weight">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkLabel" id="group_apps_label_font_weight_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">Font weight of application titles</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="group_apps_label_font_weight_combo">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">center</property>
+                        <items>
+                          <item id="inherit" translatable="yes">inherit from theme</item>
+                          <item id="normal" translatable="yes">normal</item>
+                          <item id="lighter" translatable="yes">lighter</item>
+                          <item id="bold" translatable="yes">bold</item>
+                          <item id="bolder" translatable="yes">bolder</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                        <property name="height">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
               <object class="GtkListBoxRow" id="listbox_group_apps_label_font_color">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>

--- a/appIcons.js
+++ b/appIcons.js
@@ -212,6 +212,7 @@ var taskbarAppIcon = new Lang.Class({
         this._dtpSettings.connect('changed::focus-highlight-color', Lang.bind(this, this._settingsChangeRefresh));
         this._dtpSettings.connect('changed::focus-highlight-opacity', Lang.bind(this, this._settingsChangeRefresh));
         this._dtpSettings.connect('changed::group-apps-label-font-size', Lang.bind(this, this._updateWindowTitleStyle));
+        this._dtpSettings.connect('changed::group-apps-label-font-weight', Lang.bind(this, this._updateWindowTitleStyle));
         this._dtpSettings.connect('changed::group-apps-label-font-color', Lang.bind(this, this._updateWindowTitleStyle));
         this._dtpSettings.connect('changed::group-apps-label-max-width', Lang.bind(this, this._updateWindowTitleStyle));
         this._dtpSettings.connect('changed::group-apps-use-fixed-width', Lang.bind(this, this._updateWindowTitleStyle));
@@ -447,12 +448,14 @@ var taskbarAppIcon = new Lang.Class({
             let useFixedWidth = this._dtpSettings.get_boolean('group-apps-use-fixed-width');
             let maxLabelWidth = this._dtpSettings.get_int('group-apps-label-max-width') * 
                                 St.ThemeContext.get_for_stage(global.stage).scale_factor;
+            let fontWeight = this._dtpSettings.get_string('group-apps-label-font-weight');
             
             this._windowTitle[(maxLabelWidth > 0 ? 'show' : 'hide')]();
 
             this._windowTitle.clutter_text.natural_width = useFixedWidth ? maxLabelWidth : 0;
             this._windowTitle.clutter_text.natural_width_set = useFixedWidth;
             this._windowTitle.set_style('font-size: ' + this._dtpSettings.get_int('group-apps-label-font-size') + 'px;' +
+                                        'font-weight: ' + fontWeight + ';' +
                                         (useFixedWidth ? '' : 'max-width: ' + maxLabelWidth + 'px;') + 
                                         'color: ' + this._dtpSettings.get_string('group-apps-label-font-color'));
         }

--- a/prefs.js
+++ b/prefs.js
@@ -811,6 +811,11 @@ const Settings = new Lang.Class({
                 this._settings.set_int('group-apps-label-font-size', widget.get_value());
             }));
 
+            this._builder.get_object('group_apps_label_font_weight_combo').set_active_id(this._settings.get_string('group-apps-label-font-weight'));
+            this._builder.get_object('group_apps_label_font_weight_combo').connect('changed', Lang.bind (this, function(widget) {
+                this._settings.set_string('group-apps-label-font-weight', widget.get_active_id());
+            }));
+
             (function() {
                 let rgba = new Gdk.RGBA();
                 rgba.parse(this._settings.get_string('group-apps-label-font-color'));
@@ -827,6 +832,9 @@ const Settings = new Lang.Class({
                     // restore default settings
                     this._settings.set_value('group-apps-label-font-size', this._settings.get_default_value('group-apps-label-font-size'));
                     this._builder.get_object('group_apps_label_font_size_spinbutton').set_value(this._settings.get_int('group-apps-label-font-size'));
+
+                    this._settings.set_value('group-apps-label-font-weight', this._settings.get_default_value('group-apps-label-font-weight'));
+                    this._builder.get_object('group_apps_label_font_weight_combo').set_active_id(this._settings.get_string('group-apps-label-font-weight'));
 
                     this._settings.set_value('group-apps-label-font-color', this._settings.get_default_value('group-apps-label-font-color'));
                     let rgba = new Gdk.RGBA();

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -54,6 +54,13 @@
     <value value='1' nick='FOCUSED_WINDOWS'/>
     <value value='2' nick='MAXIMIZED_WINDOWS'/>
   </enum>
+  <enum id='org.gnome.shell.extensions.dash-to-panel.fontWeight'>
+    <value value='0' nick='inherit'/>
+    <value value='1' nick='normal'/>
+    <value value='2' nick='lighter'/>
+    <value value='3' nick='bold'/>
+    <value value='4' nick='bolder'/>
+  </enum>
   <schema path="/org/gnome/shell/extensions/dash-to-panel/" id="org.gnome.shell.extensions.dash-to-panel">
     <key name="panel-position" enum="org.gnome.shell.extensions.dash-to-panel.panelPosition">
       <default>'BOTTOM'</default>
@@ -294,6 +301,11 @@
       <default>14</default>
       <summary>Application title font size</summary>
       <description>When the applications are ungrouped, this defines the application titles font size.</description>
+    </key>
+    <key name="group-apps-label-font-weight" enum="org.gnome.shell.extensions.dash-to-panel.fontWeight">
+      <default>'inherit'</default>
+      <summary>Font weight of application titles</summary>
+      <description>When the applications are ungrouped, this defines font weight of application titles. Supported values: inherit (from theme), normal, lighter, bold and bolder.</description>
     </key>
     <key type="s" name="group-apps-label-font-color">
       <default>"#dddddd"</default>


### PR DESCRIPTION
Currently when ungrouped, application titles are displayed with the default font weight.

This PR adds a combo box to the settings menu for changing of the font weight to user's preferences.

![font-weight-setting](https://user-images.githubusercontent.com/7578087/43357103-2da0c204-9285-11e8-88a9-7950db9a1709.png)

Supported values for font-weight are:

- **`inherit` (the default)**;
- `normal`;
- `lighter`;
- `bold`;
- `bolder`.

The default value is `inherit`, which keeps the font weight of the active theme.