### PR TITLE
Fix syntax error for function definition

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -518,7 +518,7 @@ var taskbarAppIcon = new Lang.Class({
         }
     },
 
-    _checkIfMonitorHasFocus() {
+    _checkIfMonitorHasFocus: function() {
         return global.display.focus_window && global.display.focus_window.get_monitor() === this.panelWrapper.monitor.index;
     },
 


### PR DESCRIPTION
It is just a small fix, but it is then usable again / testable. 
Continue the good work ;)