### PR TITLE
po: Update zh_CN translation for v17 release

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4,89 +4,122 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: dash-to-panel 14\n"
+"Project-Id-Version: dash-to-panel 17\n"
 "Report-Msgid-Bugs-To: https://github.com/jderose9/dash-to-panel/issues\n"
-"POT-Creation-Date: 2018-04-27 22:46+0800\n"
-"PO-Revision-Date: 2018-04-27 22:56+0800\n"
+"POT-Creation-Date: 2018-12-10 16:23-0500\n"
+"PO-Revision-Date: 2018-12-10 16:39-0500\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <debian-l10n-chinese@lists.debian.org>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.2\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: prefs.js:297
+#: prefs.js:312
 msgid "Running Indicator Options"
 msgstr "运行指示器选项"
 
-#: prefs.js:304 prefs.js:481 prefs.js:537 prefs.js:613 prefs.js:665
-#: prefs.js:804 prefs.js:880 prefs.js:949 prefs.js:1025 prefs.js:1067
+#: prefs.js:319 prefs.js:486 prefs.js:629 prefs.js:734 prefs.js:792
+#: prefs.js:868 prefs.js:920 prefs.js:1059 prefs.js:1143 prefs.js:1254
+#: prefs.js:1288 prefs.js:1330
 msgid "Reset to defaults"
 msgstr "恢复默认值"
 
-#: prefs.js:474
+#: prefs.js:431
+msgid "Primary monitor"
+msgstr "主显示器"
+
+#: prefs.js:434
+msgid "Monitor "
+msgstr "显示器 "
+
+#: prefs.js:479
+msgid "Multi-monitors options"
+msgstr "多显示器选项"
+
+#: prefs.js:622
+msgid "Dynamic opacity options"
+msgstr "动态半透明选项"
+
+#: prefs.js:727
 msgid "Intellihide options"
 msgstr "智能隐藏选项"
 
-#: prefs.js:530
+#: prefs.js:785
 msgid "Show Applications options"
 msgstr "“显示应用程序”选项"
 
-#: prefs.js:606
+#: prefs.js:861
 msgid "Show Desktop options"
 msgstr "“显示桌面”选项"
 
-#: prefs.js:658
+#: prefs.js:913
 msgid "Window preview options"
 msgstr "窗口预览选项"
 
-#: prefs.js:797
+#: prefs.js:1052
 msgid "Ungrouped application options"
 msgstr "未分组的应用程序选项"
 
-#: prefs.js:873
+#: prefs.js:1136
 msgid "Customize middle-click behavior"
 msgstr "自定义中键点击行为"
 
-#: prefs.js:942
+#: prefs.js:1247
 msgid "Advanced hotkeys options"
 msgstr "高级热键选项"
 
-#: prefs.js:1018
+#: prefs.js:1281
 msgid "Secondary Menu Options"
 msgstr "次级菜单选项"
 
-#: prefs.js:1060 Settings.ui.h:133
+#: prefs.js:1323 Settings.ui.h:174
 msgid "Advanced Options"
 msgstr "高级选项"
 
-#: appIcons.js:1233
+#: prefs.js:1412
+msgid "Export settings"
+msgstr "导出设置"
+
+#: prefs.js:1429
+msgid "Import settings"
+msgstr "导入设置"
+
+#: appIcons.js:1259
 msgid "Show Details"
 msgstr "显示细节"
 
-#: appIcons.js:1252
+#: appIcons.js:1278
 msgid "New Window"
 msgstr "新建窗口"
 
-#: appIcons.js:1252 appIcons.js:1314 appIcons.js:1316 Settings.ui.h:8
+#: appIcons.js:1278 appIcons.js:1340 appIcons.js:1342 Settings.ui.h:8
 msgid "Quit"
 msgstr "退出"
 
-#: appIcons.js:1316
+#: appIcons.js:1342
 msgid "Windows"
 msgstr "窗口"
 
-#: appIcons.js:1495
+#: appIcons.js:1539
+msgid "Unlock taskbar"
+msgstr "解锁任务栏"
+
+#: appIcons.js:1539
+msgid "Lock taskbar"
+msgstr "锁定任务栏"
+
+#: appIcons.js:1544
 msgid "Dash to Panel Settings"
 msgstr "Dash to Panel 设置"
 
-#: appIcons.js:1502
+#: appIcons.js:1551
 msgid "Restore Windows"
 msgstr "恢复窗口"
 
-#: appIcons.js:1502
+#: appIcons.js:1551
 msgid "Show Desktop"
 msgstr "显示桌面"
 
@@ -137,74 +170,114 @@ msgid "Shift+Middle-Click action"
 msgstr "Shift+中键点击动作"
 
 #: Settings.ui.h:13
+msgid "Isolate monitors"
+msgstr "隔离显示器"
+
+#: Settings.ui.h:14
+msgid "Display favorite applications on all monitors"
+msgstr "在所有显示器上显示收藏的应用程序"
+
+#: Settings.ui.h:15
+msgid "Display the clock on all monitors"
+msgstr "在所有显示器上显示时钟"
+
+#: Settings.ui.h:16
+msgid "Display the status menu on all monitors"
+msgstr "在所有显示器上显示状态菜单"
+
+#: Settings.ui.h:17
 msgid "Integrate <i>AppMenu</i> items"
 msgstr "集成<b>应用菜单</b>项"
 
-#: Settings.ui.h:14
+#: Settings.ui.h:18
 msgid "<i>Show Details</i> menu item"
 msgstr "<b>显示细节</b>菜单项"
 
-#: Settings.ui.h:15
+#: Settings.ui.h:19
 msgid "Highlight focused application"
 msgstr "高亮显示取得焦点的应用程序"
 
-#: Settings.ui.h:16
+#: Settings.ui.h:20
 msgid "Highlight color"
 msgstr "高亮颜色"
 
-#: Settings.ui.h:17
+#: Settings.ui.h:21
 msgid "Highlight opacity"
 msgstr "高亮不透明度"
 
-#: Settings.ui.h:18
+#: Settings.ui.h:22
 msgid "Indicator height (px)"
 msgstr "指示器高度（像素）"
 
-#: Settings.ui.h:19
+#: Settings.ui.h:23
 msgid "Indicator color - Override Theme"
 msgstr "指示器颜色 - 覆盖主题"
 
-#: Settings.ui.h:20
+#: Settings.ui.h:24
 msgid "1 window open (or ungrouped)"
 msgstr "1 窗口开启（或未分组）"
 
-#: Settings.ui.h:21
+#: Settings.ui.h:25
 msgid "Apply to all"
 msgstr "应用至全部"
 
-#: Settings.ui.h:22
+#: Settings.ui.h:26
 msgid "2 windows open"
 msgstr "2 窗口开启"
 
-#: Settings.ui.h:23
+#: Settings.ui.h:27
 msgid "3 windows open"
 msgstr "3 窗口开启"
 
-#: Settings.ui.h:24
+#: Settings.ui.h:28
 msgid "4+ windows open"
 msgstr "4+ 窗口开启"
 
-#: Settings.ui.h:25
+#: Settings.ui.h:29
 msgid "Use different for unfocused"
 msgstr "为未取得焦点的程序使用不同方案"
 
-#: Settings.ui.h:26
+#: Settings.ui.h:30
 msgid "Font size (px) of the application titles (default is 14)"
 msgstr "应用程序标题字体大小（像素）（默认值为 14）"
 
-#: Settings.ui.h:27
+#: Settings.ui.h:31
+msgid "Font weight of application titles"
+msgstr "应用程序标题字体粗细"
+
+#: Settings.ui.h:32
+msgid "inherit from theme"
+msgstr "继承自主题"
+
+#: Settings.ui.h:33
+msgid "normal"
+msgstr "正常"
+
+#: Settings.ui.h:34
+msgid "lighter"
+msgstr "较细"
+
+#: Settings.ui.h:35
+msgid "bold"
+msgstr "粗体"
+
+#: Settings.ui.h:36
+msgid "bolder"
+msgstr "更粗"
+
+#: Settings.ui.h:37
 msgid "Font color of the application titles"
 msgstr "应用程序标题字体颜色"
 
-#: Settings.ui.h:28
+#: Settings.ui.h:38
 msgid "Maximum width (px) of the application titles (default is 160)"
 msgstr "应用程序最大宽度（像素）（默认值为 160）"
 
-#: Settings.ui.h:29
+#: Settings.ui.h:39
 msgid "Use a fixed width for the application titles"
 msgstr "为应用程序标题使用固定宽度"
 
-#: Settings.ui.h:30
+#: Settings.ui.h:40
 msgid ""
 "The application titles all have the same width, even if their texts are "
 "shorter than the maximum width. The maximum width value is used as the fixed "
@@ -213,63 +286,75 @@ msgstr ""
 "应用程序标题都将使用相同宽度，即使其文本宽度无法达到最大宽度。最大宽度值将被"
 "用于固定宽度值。"
 
-#: Settings.ui.h:31
+#: Settings.ui.h:41
 msgid "Display running indicators on unfocused applications"
 msgstr "在未取得焦点的应用上显示运行指示器"
 
-#: Settings.ui.h:32
+#: Settings.ui.h:42
 msgid "Use the favorite icons as application launchers"
 msgstr "使用收藏的图标作为应用程序启动器"
 
-#: Settings.ui.h:33
+#: Settings.ui.h:43
 msgid "Only hide the panel when it is obstructed by windows "
 msgstr "仅在面板被窗口阻挡时隐藏"
 
-#: Settings.ui.h:34
+#: Settings.ui.h:44
 msgid "The panel hides from"
 msgstr "触发面板隐藏的对象"
 
-#: Settings.ui.h:35
+#: Settings.ui.h:45
 msgid "All windows"
 msgstr "所有窗口"
 
-#: Settings.ui.h:36
+#: Settings.ui.h:46
 msgid "Focused windows"
 msgstr "获得焦点的窗口"
 
-#: Settings.ui.h:37
+#: Settings.ui.h:47
 msgid "Maximized windows"
 msgstr "最大化窗口"
 
-#: Settings.ui.h:38
-msgid "Require pressure at the edge of the screen  to reveal the panel"
+#: Settings.ui.h:48
+msgid "Require pressure at the edge of the screen to reveal the panel"
 msgstr "在屏幕边缘受到一定光标压力时显示面板"
 
-#: Settings.ui.h:39
+#: Settings.ui.h:49
 msgid "Required pressure threshold (px)"
 msgstr "所需压力阈值（像素）"
 
-#: Settings.ui.h:40
+#: Settings.ui.h:50
 msgid "Required pressure timeout (ms)"
 msgstr "所需压力超时（毫秒）"
 
-#: Settings.ui.h:41
+#: Settings.ui.h:51
 msgid "Allow the panel to be revealed while in fullscreen mode"
 msgstr "允许面板在全屏幕模式下显示"
 
-#: Settings.ui.h:42
+#: Settings.ui.h:52
+msgid "e.g. <Super>i"
+msgstr "例如 <Super>i"
+
+#: Settings.ui.h:53
+msgid "Keyboard shortcut to reveal and hold the panel"
+msgstr "显示并保持面板的键盘快捷键"
+
+#: Settings.ui.h:54
+msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
+msgstr "语法：<Shift>, <Ctrl>, <Alt>, <Super>"
+
+#: Settings.ui.h:55
 msgid "Hide and reveal animation duration (ms)"
 msgstr "隐藏与显示动画持续时间（毫秒）"
 
-#: Settings.ui.h:43
+#: Settings.ui.h:56
 msgid "Delay before hiding the panel (ms)"
 msgstr "隐藏面板之前的延时（毫秒）"
 
-#: Settings.ui.h:44
+#: Settings.ui.h:57
 msgid "Preview timeout on icon leave (ms)"
 msgstr "离开图标时的预览延时（毫秒）"
 
-#: Settings.ui.h:45
+#: Settings.ui.h:58
 msgid ""
 "If set too low, the window preview of running applications may seem to close "
 "too quickly when trying to enter the popup. If set too high, the preview may "
@@ -278,143 +363,244 @@ msgstr ""
 "如果设置过低，在尝试进入弹出菜单时正在运行程序的窗口预览可能会关闭得过快。如"
 "果设置过高，在移动至临接图标时预览可能滞留过长时间。"
 
-#: Settings.ui.h:46
+#: Settings.ui.h:59
 msgid "Time (ms) before showing (100 is default)"
 msgstr "显示前的延时（毫秒，默认为 100）"
 
-#: Settings.ui.h:47
+#: Settings.ui.h:60
 msgid "Enable window peeking"
 msgstr "启用窗口概览功能"
 
-#: Settings.ui.h:48
+#: Settings.ui.h:61
 msgid ""
 "When hovering over a window preview for some time, the window gets "
 "distinguished."
 msgstr "在窗口预览上悬浮一定时间后，该窗口将被区别显示。"
 
-#: Settings.ui.h:49
+#: Settings.ui.h:62
 msgid "Enter window peeking mode timeout (ms)"
 msgstr "进入窗口概览模式延时（毫秒）"
 
-#: Settings.ui.h:50
+#: Settings.ui.h:63
 msgid ""
 "Time of inactivity while hovering over a window preview needed to enter the "
 "window peeking mode."
 msgstr "为进入窗口概览模式，需要光标悬浮在预览窗口上不活动的时间。"
 
-#: Settings.ui.h:51
+#: Settings.ui.h:64
 msgid "Window peeking mode opacity"
 msgstr "窗口概览模式不透明度"
 
-#: Settings.ui.h:52
+#: Settings.ui.h:65
 msgid ""
 "All windows except for the peeked one have their opacity set to the same "
 "value."
 msgstr "除正在处于概览状态的窗口外，其它所有窗口的不透明度将被设置为同一个值。"
 
-#: Settings.ui.h:53
+#: Settings.ui.h:66
 msgid "Middle click to close window"
 msgstr "中键点击以关闭窗口"
 
-#: Settings.ui.h:54
+#: Settings.ui.h:67
 msgid "Middle click on the preview to close the window."
 msgstr "在预览内容上中键点击以关闭窗口。"
 
-#: Settings.ui.h:55
+#: Settings.ui.h:68
 msgid "Display window title in previews"
 msgstr "在预览中显示窗口标题"
 
-#: Settings.ui.h:56
+#: Settings.ui.h:69
 msgid "Width of the window previews (px)"
 msgstr "窗口预览宽度（像素）"
 
-#: Settings.ui.h:57
+#: Settings.ui.h:70
 msgid "Height of the window previews (px)"
 msgstr "窗口预览高度（像素）"
 
-#: Settings.ui.h:58
+#: Settings.ui.h:71
 msgid "Padding of the window previews (px)"
 msgstr "窗口预览边缘宽度（像素）"
 
-#: Settings.ui.h:59
+#: Settings.ui.h:72
 msgid "Super"
 msgstr "Super"
 
-#: Settings.ui.h:60
+#: Settings.ui.h:73
 msgid "Super + Alt"
 msgstr "Super + Alt"
 
-#: Settings.ui.h:61
+#: Settings.ui.h:74
 msgid "Hotkeys prefix"
 msgstr "热键前缀"
 
-#: Settings.ui.h:62
+#: Settings.ui.h:75
 msgid "Hotkeys will either be Super+Number or Super+Alt+Num"
 msgstr "热键可以是 Super+数字 或者 Super+Alt+数字"
 
-#: Settings.ui.h:63
+#: Settings.ui.h:76
 msgid "Never"
 msgstr "从不"
 
-#: Settings.ui.h:64
+#: Settings.ui.h:77
 msgid "Show temporarily"
 msgstr "暂时显示"
 
-#: Settings.ui.h:65
+#: Settings.ui.h:78
 msgid "Always visible"
 msgstr "总是可见"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:79
 msgid "Number overlay"
 msgstr "数字附加显示"
 
-#: Settings.ui.h:67
+#: Settings.ui.h:80
 msgid ""
 "Temporarily show the application numbers over the icons when using the "
 "hotkeys."
 msgstr "使用热键时在应用图标上临时显示其对应数字。"
 
-#: Settings.ui.h:68
+#: Settings.ui.h:81
 msgid "Hide timeout (ms)"
 msgstr "隐藏延时（毫秒）"
 
-#: Settings.ui.h:69
+#: Settings.ui.h:82
+msgid "e.g. <Super>q"
+msgstr "例如 <Super>q"
+
+#: Settings.ui.h:83
 msgid "Shortcut to show the overlay for 2 seconds"
 msgstr "显示两秒钟附加数字的快捷键"
 
-#: Settings.ui.h:70
-msgid "Syntax: <Shift>, <Ctrl>, <Alt>, <Super>"
-msgstr "语法：<Shift>, <Ctrl>, <Alt>, <Super>"
+#: Settings.ui.h:84
+msgid "Show window previews on hotkey"
+msgstr "按下热键时显示窗口预览"
 
-#: Settings.ui.h:71
+#: Settings.ui.h:85
+msgid "Show previews when the application have multiple instances"
+msgstr "应用程序有多个实例时显示预览"
+
+#: Settings.ui.h:86
 msgid "Current Show Applications icon"
 msgstr "当前“显示应用程序”图标"
 
-#: Settings.ui.h:72
+#: Settings.ui.h:87
 msgid "Select a Show Applications image icon"
 msgstr "选择一个“显示应用程序”图标图像"
 
-#: Settings.ui.h:73
+#: Settings.ui.h:88
 msgid "Custom Show Applications image icon"
 msgstr "自定义“显示应用程序”图标图像"
 
-#: Settings.ui.h:74
+#: Settings.ui.h:89
 msgid "Show Desktop button width (px)"
 msgstr "“显示桌面”按钮图标宽度（像素）"
 
-#: Settings.ui.h:75
+#: Settings.ui.h:90
+msgid "The panel background opacity is affected by"
+msgstr "面板背景不透明度的影响因素"
+
+#: Settings.ui.h:91
+msgid "Change opacity when a window gets closer than (px)"
+msgstr "在窗口多靠近时修改不透明度（像素 px）"
+
+#: Settings.ui.h:93
+#, no-c-format
+msgid "Change opacity to (%)"
+msgstr "将不透明度修改为（%）"
+
+#: Settings.ui.h:94
+msgid "0"
+msgstr "0"
+
+#: Settings.ui.h:95
+msgid "Opacity change animation duration (ms)"
+msgstr "不透明度变更动画持续时间（毫秒）"
+
+#: Settings.ui.h:96
 msgid "Panel screen position"
 msgstr "面板屏幕位置"
 
-#: Settings.ui.h:76
+#: Settings.ui.h:97
 msgid "Bottom"
 msgstr "底部"
 
-#: Settings.ui.h:77
+#: Settings.ui.h:98
 msgid "Top"
 msgstr "顶部"
 
-#: Settings.ui.h:78
+#: Settings.ui.h:99
+msgid "Taskbar position"
+msgstr "任务栏位置"
+
+#: Settings.ui.h:100
+msgid "Left, with plugin icons collapsed to right"
+msgstr "左侧，并且插件图标收缩到右侧"
+
+#: Settings.ui.h:101
+msgid "Left, with fixed center plugin icons"
+msgstr "左侧，并且固定居中插件图标"
+
+#: Settings.ui.h:102
+msgid "Left, with floating center plugin icons"
+msgstr "左侧，并且浮动居中插件图标"
+
+#: Settings.ui.h:103
+msgid "Center, fixed in middle of monitor"
+msgstr "中间，固定在显示屏中间"
+
+#: Settings.ui.h:104
+msgid "Center, floating between left and right elements"
+msgstr "中间，在左侧元素和右侧元素之间浮动"
+
+#: Settings.ui.h:105
+msgid "Clock location"
+msgstr "时钟位置"
+
+#: Settings.ui.h:106
+msgid "Left of plugin icons"
+msgstr "插件图标左侧"
+
+#: Settings.ui.h:107
+msgid "Right of plugin icons"
+msgstr "插件图标右侧"
+
+#: Settings.ui.h:108
+msgid "Left of system indicators"
+msgstr "系统指示器左侧"
+
+#: Settings.ui.h:109
+msgid "Right of system indicators"
+msgstr "系统指示器右侧"
+
+#: Settings.ui.h:110
+msgid "Left of taskbar"
+msgstr "任务栏左侧"
+
+#: Settings.ui.h:111
+msgid "Right of taskbar"
+msgstr "任务栏右侧"
+
+#: Settings.ui.h:112
+msgid "Display the main panel on"
+msgstr "将主面板显示于"
+
+#: Settings.ui.h:113
+msgid "Display panels on all monitors"
+msgstr "在所有显示器上显示面板"
+
+#: Settings.ui.h:114
+msgid "Panel Intellihide"
+msgstr "面板智能隐藏"
+
+#: Settings.ui.h:115
+msgid "Hide and reveal the panel according to preferences"
+msgstr "按照配置隐藏和显示面板"
+
+#: Settings.ui.h:116
+msgid "Position"
+msgstr "位置"
+
+#: Settings.ui.h:117
 msgid ""
 "Panel Size\n"
 "(default is 48)"
@@ -422,7 +608,7 @@ msgstr ""
 "面板大小\n"
 "（默认为 48）"
 
-#: Settings.ui.h:80
+#: Settings.ui.h:119
 msgid ""
 "App Icon Margin\n"
 "(default is 8)"
@@ -430,7 +616,7 @@ msgstr ""
 "应用图标边缘空白\n"
 "（默认为 8）"
 
-#: Settings.ui.h:82
+#: Settings.ui.h:121
 msgid ""
 "App Icon Padding\n"
 "(default is 4)"
@@ -438,154 +624,149 @@ msgstr ""
 "应用图标边缘空白\n"
 "（默认为 4）"
 
-#: Settings.ui.h:84
+#: Settings.ui.h:123
 msgid "Running indicator position"
 msgstr "运行指示器位置"
 
-#: Settings.ui.h:85
+#: Settings.ui.h:124
 msgid "Running indicator style (Focused app)"
 msgstr "运行指示器风格（取得焦点的应用）"
 
-#: Settings.ui.h:86
+#: Settings.ui.h:125
 msgid "Dots"
 msgstr "点"
 
-#: Settings.ui.h:87
+#: Settings.ui.h:126
 msgid "Squares"
 msgstr "方块"
 
-#: Settings.ui.h:88
+#: Settings.ui.h:127
 msgid "Dashes"
 msgstr "横线"
 
-#: Settings.ui.h:89
+#: Settings.ui.h:128
 msgid "Segmented"
 msgstr "间断线"
 
-#: Settings.ui.h:90
+#: Settings.ui.h:129
 msgid "Solid"
 msgstr "实心"
 
-#: Settings.ui.h:91
+#: Settings.ui.h:130
 msgid "Ciliora"
 msgstr "Ciliora"
 
-#: Settings.ui.h:92
+#: Settings.ui.h:131
 msgid "Metro"
 msgstr "Metro"
 
-#: Settings.ui.h:93
+#: Settings.ui.h:132
 msgid "Running indicator style (Unfocused apps)"
 msgstr "运行指示器风格（未取得焦点的应用）"
 
-#: Settings.ui.h:94
-msgid "Clock location"
-msgstr "时钟位置"
+#: Settings.ui.h:133
+msgid "Override panel theme background color "
+msgstr "覆盖面板主题背景颜色 "
 
-#: Settings.ui.h:95
-msgid "Natural"
-msgstr "自然"
+#: Settings.ui.h:134
+msgid "Override panel theme background opacity"
+msgstr "覆盖面板主题背景不透明度"
 
-#: Settings.ui.h:96
-msgid "Left of status menu"
-msgstr "状态菜单左侧"
+#: Settings.ui.h:136
+#, no-c-format
+msgid "Panel background opacity (%)"
+msgstr "面板背景不透明度（%）"
 
-#: Settings.ui.h:97
-msgid "Right of status menu"
-msgstr "状态菜单右侧"
+#: Settings.ui.h:137
+msgid "Dynamic background opacity"
+msgstr "动态背景不透明度"
 
-#: Settings.ui.h:98
-msgid "Taskbar position"
-msgstr "任务栏位置"
+#: Settings.ui.h:138
+msgid "Change opacity when a window gets close to the panel"
+msgstr "在有窗口接近面板时修改不透明度"
 
-#: Settings.ui.h:99
-msgid "Left side of panel"
-msgstr "面板左侧"
+#: Settings.ui.h:139
+msgid "Override panel theme gradient "
+msgstr "覆盖面板主题渐变 "
 
-#: Settings.ui.h:100
-msgid "Centered in monitor"
-msgstr "显示器居中"
+#: Settings.ui.h:141
+#, no-c-format
+msgid "Gradient top color and opacity (%)"
+msgstr "渐变顶部颜色和不透明度（%）"
 
-#: Settings.ui.h:101
-msgid "Centered in content"
-msgstr "内容居中"
+#: Settings.ui.h:143
+#, no-c-format
+msgid "Gradient bottom color and opacity (%)"
+msgstr "渐变底部颜色和不透明度（%）"
 
-#: Settings.ui.h:102
-msgid "Panel Intellihide"
-msgstr "面板智能隐藏"
+#: Settings.ui.h:144
+msgid "Style"
+msgstr "风格"
 
-#: Settings.ui.h:103
-msgid "Hide and reveal the panel according to preferences"
-msgstr "按照配置隐藏和显示面板"
-
-#: Settings.ui.h:104
-msgid "Position and Style"
-msgstr "位置和风格"
-
-#: Settings.ui.h:105
+#: Settings.ui.h:145
 msgid "Show favorite applications"
 msgstr "显示收藏的应用程序"
 
-#: Settings.ui.h:106
+#: Settings.ui.h:146
 msgid "Show <i>Applications</i> icon"
 msgstr "显示<b>应用</b>图标"
 
-#: Settings.ui.h:107
+#: Settings.ui.h:147
 msgid "Animate <i>Show Applications</i>."
 msgstr "动画化<b>显示应用程序</b>。"
 
-#: Settings.ui.h:108
+#: Settings.ui.h:148
 msgid "Show <i>Activities</i> button"
 msgstr "显示<b>活动</b>按钮"
 
-#: Settings.ui.h:109
+#: Settings.ui.h:149
 msgid "Show <i>Desktop</i> button"
 msgstr "显示<b>桌面</b>按钮"
 
-#: Settings.ui.h:110
+#: Settings.ui.h:150
 msgid "Show <i>AppMenu</i> button"
 msgstr "显示<b>应用菜单</b>按钮"
 
-#: Settings.ui.h:111
+#: Settings.ui.h:151
 msgid "Top Bar > Show App Menu must be enabled in Tweak Tool"
 msgstr "必须在优化工具中启用顶栏 > 显示应用菜单"
 
-#: Settings.ui.h:112
+#: Settings.ui.h:152
 msgid "Show window previews on hover"
 msgstr "悬停时显示窗口预览"
 
-#: Settings.ui.h:113
+#: Settings.ui.h:153
 msgid "Isolate Workspaces"
 msgstr "隔离工作区"
 
-#: Settings.ui.h:114
+#: Settings.ui.h:154
 msgid "Ungroup applications"
 msgstr "取消应用程序分组"
 
-#: Settings.ui.h:115
+#: Settings.ui.h:155
 msgid "Behaviour when clicking on the icon of a running application."
 msgstr "点击正在运行应用程序图标时的行为。"
 
-#: Settings.ui.h:116
+#: Settings.ui.h:156
 msgid "Click action"
 msgstr "点击行为"
 
-#: Settings.ui.h:117
+#: Settings.ui.h:157
 msgid ""
 "Enable Super+(0-9) as shortcuts to activate apps. It can also be used "
 "together with Shift and Ctrl."
 msgstr ""
 "将 Super+(0-9) 作为激活应用程序的快捷键。它也可以和 Shift 或 Ctrl 共同使用。"
 
-#: Settings.ui.h:118
+#: Settings.ui.h:158
 msgid "Use hotkeys to activate apps"
 msgstr "使用热键激活应用"
 
-#: Settings.ui.h:119
+#: Settings.ui.h:159
 msgid "Behavior"
 msgstr "行为"
 
-#: Settings.ui.h:120
+#: Settings.ui.h:160
 msgid ""
 "Tray Font Size\n"
 "(0 = theme default)"
@@ -593,7 +774,7 @@ msgstr ""
 "托盘字体大小\n"
 "（0 = 主题默认）"
 
-#: Settings.ui.h:122
+#: Settings.ui.h:162
 msgid ""
 "LeftBox Font Size\n"
 "(0 = theme default)"
@@ -601,7 +782,7 @@ msgstr ""
 "LeftBox 字体大小\n"
 "（0 = 主题默认）"
 
-#: Settings.ui.h:124
+#: Settings.ui.h:164
 msgid ""
 "Tray Item Padding\n"
 "(-1 = theme default)"
@@ -609,7 +790,7 @@ msgstr ""
 "托盘项边缘空白\n"
 "（-1 = 主题默认）"
 
-#: Settings.ui.h:126
+#: Settings.ui.h:166
 msgid ""
 "Status Icon Padding\n"
 "(-1 = theme default)"
@@ -617,7 +798,7 @@ msgstr ""
 "状态图标边缘空白\n"
 "（-1 = 主题默认）"
 
-#: Settings.ui.h:128
+#: Settings.ui.h:168
 msgid ""
 "LeftBox Padding\n"
 "(-1 = theme default)"
@@ -625,31 +806,55 @@ msgstr ""
 "LeftBox 边缘空白\n"
 "（-1 = 主题默认）"
 
-#: Settings.ui.h:130
+#: Settings.ui.h:170
 msgid "Animate switching applications"
 msgstr "动画切换应用程序"
 
-#: Settings.ui.h:131
+#: Settings.ui.h:171
 msgid "Animate launching new windows"
 msgstr "动画启动新窗口"
 
-#: Settings.ui.h:132
+#: Settings.ui.h:172
+msgid "Keep original gnome-shell dash (overview)"
+msgstr "保持原始 gnome-shell dash（预览）"
+
+#: Settings.ui.h:173
 msgid "App icon secondary (right-click) menu"
 msgstr "应用图标次级（右键点击）菜单"
 
-#: Settings.ui.h:134
+#: Settings.ui.h:175
 msgid "Fine-Tune"
 msgstr "微调"
 
-#: Settings.ui.h:135
+#: Settings.ui.h:176
 msgid "version: "
 msgstr "版本："
 
-#: Settings.ui.h:136
-msgid "Github"
-msgstr "Github"
+#: Settings.ui.h:177
+msgid "GitHub"
+msgstr "GitHub"
 
-#: Settings.ui.h:137
+#: Settings.ui.h:178
+msgid ""
+"Use the buttons below to create a settings file from your current "
+"preferences that can be imported on a different machine."
+msgstr ""
+"使用下面的按钮以基于您当前的首选项创建一个设置文件；您稍后可使用该文件在其他"
+"机器上导入设置。"
+
+#: Settings.ui.h:179
+msgid "Export and import settings"
+msgstr "导入导出设置"
+
+#: Settings.ui.h:180
+msgid "Export to file"
+msgstr "导出至文件"
+
+#: Settings.ui.h:181
+msgid "Import from file"
+msgstr "从文件导入"
+
+#: Settings.ui.h:182
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -659,12 +864,21 @@ msgstr ""
 "请查看 <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
 "\">GNU 通用公共许可证，第二版或更新版本</a> 以了解详情。</span>"
 
-#: Settings.ui.h:139
+#: Settings.ui.h:184
 msgid "About"
 msgstr "关于"
 
+#~ msgid "Natural"
+#~ msgstr "自然"
+
+#~ msgid "Left side of panel"
+#~ msgstr "面板左侧"
+
+#~ msgid "Centered in content"
+#~ msgstr "内容居中"
+
+#~ msgid "Github"
+#~ msgstr "Github"
+
 #~ msgid "5"
 #~ msgstr "5"
-
-#~ msgid "0"
-#~ msgstr "0"


### PR DESCRIPTION
This commit finishes `zh_CN` (Simplified Chinese) translation of dash-to-panel v17.