### PR TITLE
Fix fix taskbar allocation

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -414,17 +414,21 @@ var dtpPanelWrapper = new Lang.Class({
         // Now figure out how large the _leftBox and _centerBox should be.
         // The box with the taskbar is always the one that is forced to be smaller as the other boxes grow
         let leftAllocWidth, centerStartPosition, centerEndPosition;
+        
         // HFADE_WIDTH is the width of the empty space at the end of the taskbar (see Taskbar.TaskbarActor.vfunc_get_preferred_width)
+        let hasOffset = this._dtpSettings.get_string('location-clock') != 'BUTTONSRIGHT' && this._dtpSettings.get_string('location-clock') != 'TASKBARRIGHT';
+        let offset = hasOffset ? Taskbar.HFADE_WIDTH : 0;
+        
         if (taskbarPosition == 'CENTEREDMONITOR') {
             leftAllocWidth = leftNaturalWidth;
 
-            centerStartPosition = Math.max(leftNaturalWidth, Math.floor((panelAllocWidth - centerNaturalWidth + Taskbar.HFADE_WIDTH)/2));
-            centerEndPosition = Math.min(panelAllocWidth-rightNaturalWidth, Math.ceil((panelAllocWidth+centerNaturalWidth + Taskbar.HFADE_WIDTH))/2);
+            centerStartPosition = Math.max(leftNaturalWidth, Math.floor((panelAllocWidth - centerNaturalWidth + offset)/2));
+            centerEndPosition = Math.min(panelAllocWidth-rightNaturalWidth, Math.ceil((panelAllocWidth+centerNaturalWidth + offset))/2);
         } else if (taskbarPosition == 'CENTEREDCONTENT') {
             leftAllocWidth = leftNaturalWidth;
 
-            centerStartPosition = Math.max(leftNaturalWidth, Math.floor((panelAllocWidth - centerNaturalWidth + leftNaturalWidth - rightNaturalWidth + Taskbar.HFADE_WIDTH) / 2));
-            centerEndPosition = Math.min(panelAllocWidth-rightNaturalWidth, Math.ceil((panelAllocWidth + centerNaturalWidth + leftNaturalWidth - rightNaturalWidth + Taskbar.HFADE_WIDTH) / 2));
+            centerStartPosition = Math.max(leftNaturalWidth, Math.floor((panelAllocWidth - centerNaturalWidth + leftNaturalWidth - rightNaturalWidth + offset) / 2));
+            centerEndPosition = Math.min(panelAllocWidth-rightNaturalWidth, Math.ceil((panelAllocWidth + centerNaturalWidth + leftNaturalWidth - rightNaturalWidth + offset) / 2));
         } else if (taskbarPosition == 'LEFTPANEL_FIXEDCENTER') {
             leftAllocWidth = Math.floor((panelAllocWidth - centerNaturalWidth) / 2);
             centerStartPosition = leftAllocWidth;

--- a/taskbar.js
+++ b/taskbar.js
@@ -183,7 +183,8 @@ var taskbar = new Lang.Class({
         this.showAppsButton = this._showAppsIcon.toggleButton;
              
         this.showAppsButton.connect('notify::checked', Lang.bind(this, this._onShowAppsButtonToggled));
-        this.showAppsButton.connect('notify::width', Lang.bind(this, this.updateScrollViewSizeConstraint));
+        if (this.panelWrapper.panel.actor.get_text_direction() != Clutter.TextDirection.RTL)
+            this.showAppsButton.connect('notify::width', Lang.bind(this, this.updateScrollViewSizeConstraint));
         this.showAppsButton.checked = Main.overview.viewSelector._showAppsButton.checked;
 
         this._showAppsIcon.childScale = 1;


### PR DESCRIPTION
follow #538 .
Don't add size constraint on scrollView when text direction is RTL (strange behaviour).

And when the clock is located immediately after the taskbar, there is no need to add an offset.