### PR TITLE
Only check monitor index if multi monitor is enabled.

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -519,7 +519,9 @@ var taskbarAppIcon = new Lang.Class({
     },
 
     _checkIfMonitorHasFocus: function() {
-        return global.display.focus_window && global.display.focus_window.get_monitor() === this.panelWrapper.monitor.index;
+        return global.display.focus_window
+            && (!this._dtpSettings.get_boolean('multi-monitors')    // only check same monitor index if multi window is enabled.
+                    || global.display.focus_window.get_monitor() === this.panelWrapper.monitor.index);
     },
 
     _setAppIconPadding: function() {


### PR DESCRIPTION
When using multiple physical monitors and disabled multi monitor in DTP, the focused application on the secondary monitor does not have a highlight on the icon in the panel.

This checks to see if multi monitor setting is enabled, before checking if the current monitor is active.