### PR TITLE
port DominantColorExtractor from dash-to-dock

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -839,18 +839,43 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="margin_left">12</property>
-                        <property name="row_spacing">4</property>
+                        <property name="row_spacing">8</property>
                         <child>
-                          <object class="GtkLabel" id="focus_highlight_color_label">
+                          <object class="GtkLabel" id="focus_highlight_dominant_label">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="hexpand">True</property>
-                            <property name="label" translatable="yes">Highlight color</property>
+                            <property name="label" translatable="yes">Icon dominant color</property>
                             <property name="xalign">0</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
                             <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="focus_highlight_dominant_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="focus_highlight_color_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Custom color</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
                           </packing>
                         </child>
                         <child>
@@ -862,7 +887,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">0</property>
+                            <property name="top_attach">1</property>
                           </packing>
                         </child>
                         <child>
@@ -875,7 +900,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
@@ -889,7 +914,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                       </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -948,6 +948,49 @@
               </object>
             </child>
             <child>
+              <object class="GtkListBoxRow" id="listboxrow_dot_dominant">
+                <property name="width_request">100</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkGrid" id="grid_dot_dominant">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="column_spacing">32</property>
+                    <child>
+                      <object class="GtkLabel" id="dot_dominant_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">Indicator color - Icon Dominant</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="dot_color_dominant_switch">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
               <object class="GtkListBoxRow" id="listboxrow_dot_color">
                 <property name="width_request">100</property>
                 <property name="height_request">80</property>

--- a/appIcons.js
+++ b/appIcons.js
@@ -214,6 +214,7 @@ var taskbarAppIcon = Utils.defineClass({
             this._dtpSettings.connect('changed::dot-color-unfocused-3', Lang.bind(this, this._settingsChangeRefresh)),
             this._dtpSettings.connect('changed::dot-color-unfocused-4', Lang.bind(this, this._settingsChangeRefresh)),
             this._dtpSettings.connect('changed::focus-highlight', Lang.bind(this, this._settingsChangeRefresh)),
+            this._dtpSettings.connect('changed::focus-highlight-dominant', Lang.bind(this, this._settingsChangeRefresh)),
             this._dtpSettings.connect('changed::focus-highlight-color', Lang.bind(this, this._settingsChangeRefresh)),
             this._dtpSettings.connect('changed::focus-highlight-opacity', Lang.bind(this, this._settingsChangeRefresh)),
             this._dtpSettings.connect('changed::group-apps-label-font-size', Lang.bind(this, this._updateWindowTitleStyle)),
@@ -510,8 +511,8 @@ var taskbarAppIcon = Utils.defineClass({
                 }
             }
 
-            inlineStyle += "background-color: " + cssHexTocssRgba(this._dtpSettings.get_string('focus-highlight-color'), 
-                                                                  this._dtpSettings.get_int('focus-highlight-opacity') * 0.01);
+            let highlightColor = this._getFocusHighlightColor();
+            inlineStyle += "background-color: " + cssHexTocssRgba(highlightColor, this._dtpSettings.get_int('focus-highlight-opacity') * 0.01);
         }
         
         if(this._dotsContainer.get_style() != inlineStyle) {
@@ -955,6 +956,15 @@ var taskbarAppIcon = Utils.defineClass({
         }
 
         return color;
+    },
+
+    _getFocusHighlightColor: function() {
+        if (this._dtpSettings.get_boolean('focus-highlight-dominant')) {
+            let dce = new Utils.DominantColorExtractor(this.app);
+            let palette = dce._getColorPalette();
+            if (palette) return palette.original;
+        }
+        return this._dtpSettings.get_string('focus-highlight-color');
     },
 
     _drawRunningIndicator: function(area, type, isFocused) {

--- a/prefs.js
+++ b/prefs.js
@@ -377,6 +377,22 @@ const Settings = new Lang.Class({
                     'sensitive',
                     Gio.SettingsBindFlags.DEFAULT);
 
+            this._settings.bind('focus-highlight-dominant',
+                    this._builder.get_object('focus_highlight_dominant_switch'),
+                    'active',
+                    Gio.SettingsBindFlags.DEFAULT);
+
+            this._settings.bind('focus-highlight-dominant',
+                    this._builder.get_object('focus_highlight_color_label'),
+                    'sensitive',
+                    Gio.SettingsBindFlags.INVERT_BOOLEAN);
+
+            this._settings.bind('focus-highlight-dominant',
+                    this._builder.get_object('focus_highlight_color_colorbutton'),
+                    'sensitive',
+                    Gio.SettingsBindFlags.INVERT_BOOLEAN);
+
+
             (function() {
                 let rgba = new Gdk.RGBA();
                 rgba.parse(this._settings.get_string('focus-highlight-color'));
@@ -424,6 +440,7 @@ const Settings = new Lang.Class({
                     this._builder.get_object('dot_size_spinbutton').set_value(this._settings.get_int('dot-size'));
                    
                     this._settings.set_value('focus-highlight', this._settings.get_default_value('focus-highlight'));
+                    this._settings.set_value('focus-highlight-dominant', this._settings.get_default_value('focus-highlight-dominant'));
 
                 } else {
                     // remove the settings box so it doesn't get destroyed;

--- a/prefs.js
+++ b/prefs.js
@@ -319,10 +319,23 @@ const Settings = new Lang.Class({
             let box = this._builder.get_object('box_dots_options');
             dialog.get_content_area().add(box);
 
+            this._settings.bind('dot-color-dominant',
+                            this._builder.get_object('dot_color_dominant_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+
             this._settings.bind('dot-color-override',
                             this._builder.get_object('dot_color_override_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+
+            // when either becomes active, turn the other off
+            this._builder.get_object('dot_color_dominant_switch').connect('state-set', Lang.bind (this, function(widget) {
+                if (widget.get_active()) this._settings.set_boolean('dot-color-override', false);
+            }));
+            this._builder.get_object('dot_color_override_switch').connect('state-set', Lang.bind (this, function(widget) {
+                if (widget.get_active()) this._settings.set_boolean('dot-color-dominant', false);
+            }));
 
             this._settings.bind('dot-color-unfocused-different',
                             this._builder.get_object('dot_color_unfocused_different_switch'),
@@ -383,6 +396,7 @@ const Settings = new Lang.Class({
             dialog.connect('response', Lang.bind(this, function(dialog, id) {
                 if (id == 1) {
                     // restore default settings
+                    this._settings.set_value('dot-color-dominant', this._settings.get_default_value('dot-color-dominant'));
                     this._settings.set_value('dot-color-override', this._settings.get_default_value('dot-color-override'));
                     this._settings.set_value('dot-color-unfocused-different', this._settings.get_default_value('dot-color-unfocused-different'));
 

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -90,6 +90,11 @@
       <summary>Style of the running indicator (unfocused)</summary>
       <description>Style of the running indicator for the icon for applications which are not currently focused</description>
     </key>
+    <key type="b" name="dot-color-dominant">
+      <default>false</default>
+      <summary>Running indicator dominant color</summary>
+      <description>Whether to use the app icon's dominant color for .app-well-running-dot</description>
+    </key>
     <key type="b" name="dot-color-override">
       <default>false</default>
       <summary>Running indicator color override</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -155,6 +155,11 @@
       <summary>Highlight icon of focused application</summary>
       <description>Whether to highlight the background of the currently focused application's icon</description>
     </key>
+    <key type="b" name="focus-highlight-dominant">
+      <default>false</default>
+      <summary>Highlight icon dominant color</summary>
+      <description>Base the active window highlight color on that application's icon</description>
+    </key>
     <key type="s" name="focus-highlight-color">
       <default>"#EEEEEE"</default>
       <summary>Color of highlight of focused application</summary>

--- a/utils.js
+++ b/utils.js
@@ -21,10 +21,14 @@
  * Some code was also adapted from the upstream Gnome Shell source code.
  */
 
+const GdkPixbuf = imports.gi.GdkPixbuf
 const Gi = imports._gi;
+const Gio = imports.gi.Gio;
 const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
+const St = imports.gi.St;
 const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
 
@@ -292,3 +296,293 @@ var removeKeybinding = function(key) {
         Main.wm.removeKeybinding(key);
     }
 };
+ 
+/**
+ *  ColorUtils is adapted from https://github.com/micheleg/dash-to-dock
+ */
+var ColorUtils = {
+    colorLuminance: function(r, g, b, dlum) {
+        // Darken or brighten color by a fraction dlum
+        // Each rgb value is modified by the same fraction.
+        // Return "#rrggbb" strin
+
+        let rgbString = '#';
+
+        rgbString += ColorUtils._decimalToHex(Math.round(Math.min(Math.max(r*(1+dlum), 0), 255)), 2);
+        rgbString += ColorUtils._decimalToHex(Math.round(Math.min(Math.max(g*(1+dlum), 0), 255)), 2);
+        rgbString += ColorUtils._decimalToHex(Math.round(Math.min(Math.max(b*(1+dlum), 0), 255)), 2);
+
+        return rgbString;
+    },
+
+    _decimalToHex: function(d, padding) {
+        // Convert decimal to an hexadecimal string adding the desired padding
+
+        let hex = d.toString(16);
+        while (hex.length < padding)
+            hex = '0'+ hex;
+        return hex;
+    },
+
+    HSVtoRGB: function(h, s, v) {
+        // Convert hsv ([0-1, 0-1, 0-1]) to rgb ([0-255, 0-255, 0-255]).
+        // Following algorithm in https://en.wikipedia.org/wiki/HSL_and_HSV
+        // here with h = [0,1] instead of [0, 360]
+        // Accept either (h,s,v) independently or  {h:h, s:s, v:v} object.
+        // Return {r:r, g:g, b:b} object.
+
+        if (arguments.length === 1) {
+            s = h.s;
+            v = h.v;
+            h = h.h;
+        }
+
+        let r,g,b;
+        let c = v*s;
+        let h1 = h*6;
+        let x = c*(1 - Math.abs(h1 % 2 - 1));
+        let m = v - c;
+
+        if (h1 <=1)
+            r = c + m, g = x + m, b = m;
+        else if (h1 <=2)
+            r = x + m, g = c + m, b = m;
+        else if (h1 <=3)
+            r = m, g = c + m, b = x + m;
+        else if (h1 <=4)
+            r = m, g = x + m, b = c + m;
+        else if (h1 <=5)
+            r = x + m, g = m, b = c + m;
+        else
+            r = c + m, g = m, b = x + m;
+
+        return {
+            r: Math.round(r * 255),
+            g: Math.round(g * 255),
+            b: Math.round(b * 255)
+        };
+    },
+
+    RGBtoHSV: function(r, g, b) {
+        // Convert rgb ([0-255, 0-255, 0-255]) to hsv ([0-1, 0-1, 0-1]).
+        // Following algorithm in https://en.wikipedia.org/wiki/HSL_and_HSV
+        // here with h = [0,1] instead of [0, 360]
+        // Accept either (r,g,b) independently or {r:r, g:g, b:b} object.
+        // Return {h:h, s:s, v:v} object.
+
+        if (arguments.length === 1) {
+            r = r.r;
+            g = r.g;
+            b = r.b;
+        }
+
+        let h,s,v;
+
+        let M = Math.max(r, g, b);
+        let m = Math.min(r, g, b);
+        let c = M - m;
+
+        if (c == 0)
+            h = 0;
+        else if (M == r)
+            h = ((g-b)/c) % 6;
+        else if (M == g)
+            h = (b-r)/c + 2;
+        else
+            h = (r-g)/c + 4;
+
+        h = h/6;
+        v = M/255;
+        if (M !== 0)
+            s = c/M;
+        else
+            s = 0;
+
+        return {h, s, v};
+    }
+};
+
+/**
+ *  DominantColorExtractor is adapted from https://github.com/micheleg/dash-to-dock
+ */
+let themeLoader = null;
+let iconCacheMap = new Map();
+const MAX_CACHED_ITEMS = 1000;
+const BATCH_SIZE_TO_DELETE = 50;
+const DOMINANT_COLOR_ICON_SIZE = 64;
+
+var DominantColorExtractor = defineClass({
+    Name: 'DashToPanel.DominantColorExtractor',
+
+    _init: function(app){
+        this._app = app;
+    },
+
+    /**
+     * Try to get the pixel buffer for the current icon, if not fail gracefully
+     */
+    _getIconPixBuf: function() {
+        let iconTexture = this._app.create_icon_texture(16);
+
+        if (themeLoader === null) {
+            let ifaceSettings = new Gio.Settings({ schema: "org.gnome.desktop.interface" });
+
+            themeLoader = new Gtk.IconTheme(),
+            themeLoader.set_custom_theme(ifaceSettings.get_string('icon-theme')); // Make sure the correct theme is loaded
+        }
+
+        // Unable to load the icon texture, use fallback
+        if (iconTexture instanceof St.Icon === false) {
+            return null;
+        }
+
+        iconTexture = iconTexture.get_gicon();
+
+        // Unable to load the icon texture, use fallback
+        if (iconTexture === null) {
+            return null;
+        }
+
+        if (iconTexture instanceof Gio.FileIcon) {
+            // Use GdkPixBuf to load the pixel buffer from the provided file path
+            return GdkPixbuf.Pixbuf.new_from_file(iconTexture.get_file().get_path());
+        }
+
+        // Get the pixel buffer from the icon theme
+        let icon_info = themeLoader.lookup_icon(iconTexture.get_names()[0], DOMINANT_COLOR_ICON_SIZE, 0);
+        if (icon_info !== null)
+            return icon_info.load_icon();
+        else
+            return null;
+    },
+
+    /**
+     * The backlight color choosing algorithm was mostly ported to javascript from the
+     * Unity7 C++ source of Canonicals:
+     * https://bazaar.launchpad.net/~unity-team/unity/trunk/view/head:/launcher/LauncherIcon.cpp
+     * so it more or less works the same way.
+     */
+    _getColorPalette: function() {
+        if (iconCacheMap.get(this._app.get_id())) {
+            // We already know the answer
+            return iconCacheMap.get(this._app.get_id());
+        }
+
+        let pixBuf = this._getIconPixBuf();
+        if (pixBuf == null)
+            return null;
+
+        let pixels = pixBuf.get_pixels(),
+            offset = 0;
+
+        let total  = 0,
+            rTotal = 0,
+            gTotal = 0,
+            bTotal = 0;
+
+        let resample_y = 1,
+            resample_x = 1;
+
+        // Resampling of large icons
+        // We resample icons larger than twice the desired size, as the resampling
+        // to a size s
+        // DOMINANT_COLOR_ICON_SIZE < s < 2*DOMINANT_COLOR_ICON_SIZE,
+        // most of the case exactly DOMINANT_COLOR_ICON_SIZE as the icon size is tipycally
+        // a multiple of it.
+        let width = pixBuf.get_width();
+        let height = pixBuf.get_height();
+
+        // Resample
+        if (height >= 2* DOMINANT_COLOR_ICON_SIZE)
+            resample_y = Math.floor(height/DOMINANT_COLOR_ICON_SIZE);
+
+        if (width >= 2* DOMINANT_COLOR_ICON_SIZE)
+            resample_x = Math.floor(width/DOMINANT_COLOR_ICON_SIZE);
+
+        if (resample_x !==1 || resample_y !== 1)
+            pixels = this._resamplePixels(pixels, resample_x, resample_y);
+
+        // computing the limit outside the for (where it would be repeated at each iteration)
+        // for performance reasons
+        let limit = pixels.length;
+        for (let offset = 0; offset < limit; offset+=4) {
+            let r = pixels[offset],
+                g = pixels[offset + 1],
+                b = pixels[offset + 2],
+                a = pixels[offset + 3];
+
+            let saturation = (Math.max(r,g, b) - Math.min(r,g, b));
+            let relevance  = 0.1 * 255 * 255 + 0.9 * a * saturation;
+
+            rTotal += r * relevance;
+            gTotal += g * relevance;
+            bTotal += b * relevance;
+
+            total += relevance;
+        }
+
+        total = total * 255;
+
+        let r = rTotal / total,
+            g = gTotal / total,
+            b = bTotal / total;
+
+        let hsv = ColorUtils.RGBtoHSV(r * 255, g * 255, b * 255);
+
+        if (hsv.s > 0.15)
+            hsv.s = 0.65;
+        hsv.v = 0.90;
+
+        let rgb = ColorUtils.HSVtoRGB(hsv.h, hsv.s, hsv.v);
+
+        // Cache the result.
+        let backgroundColor = {
+            lighter:  ColorUtils.colorLuminance(rgb.r, rgb.g, rgb.b, 0.2),
+            original: ColorUtils.colorLuminance(rgb.r, rgb.g, rgb.b, 0),
+            darker:   ColorUtils.colorLuminance(rgb.r, rgb.g, rgb.b, -0.5)
+        };
+
+        if (iconCacheMap.size >= MAX_CACHED_ITEMS) {
+            //delete oldest cached values (which are in order of insertions)
+            let ctr=0;
+            for (let key of iconCacheMap.keys()) {
+                if (++ctr > BATCH_SIZE_TO_DELETE)
+                    break;
+                iconCacheMap.delete(key);
+            }
+        }
+
+        iconCacheMap.set(this._app.get_id(), backgroundColor);
+
+        return backgroundColor;
+    },
+
+    /**
+     * Downsample large icons before scanning for the backlight color to
+     * improve performance.
+     *
+     * @param pixBuf
+     * @param pixels
+     * @param resampleX
+     * @param resampleY
+     *
+     * @return [];
+     */
+    _resamplePixels (pixels, resampleX, resampleY) {
+        let resampledPixels = [];
+        // computing the limit outside the for (where it would be repeated at each iteration)
+        // for performance reasons
+        let limit = pixels.length / (resampleX * resampleY) / 4;
+        for (let i = 0; i < limit; i++) {
+            let pixel = i * resampleX * resampleY;
+
+            resampledPixels.push(pixels[pixel * 4]);
+            resampledPixels.push(pixels[pixel * 4 + 1]);
+            resampledPixels.push(pixels[pixel * 4 + 2]);
+            resampledPixels.push(pixels[pixel * 4 + 3]);
+        }
+
+        return resampledPixels;
+    }
+
+});


### PR DESCRIPTION
This adds the "use dominant color" functionality seen in [dash-to-dock](https://github.com/micheleg/dash-to-dock/blob/master/appIconIndicators.js#L951). 

Screenshot of the feature in action:
![Screenshot from 2019-05-02 13-40-56](https://user-images.githubusercontent.com/8548090/57106508-6a19df80-6ce2-11e9-8f43-d4df8778203b.png)

I added a switch in the prefs dialog. Activating either "Icon Dominant" or "Override Theme" will deactivate the other switch. Deactivating both will result in using the theme default color.

Screenshot of prefs dialog:
![prefs](https://user-images.githubusercontent.com/8548090/57106620-bd8c2d80-6ce2-11e9-94b8-d1017fa2dada.png)
