### PR TITLE
Show preview windows via TOGGLE-SHOWEPREVIEW buttonAction. Closes: #696

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -253,16 +253,33 @@ var taskbarAppIcon = Utils.defineClass({
     },
 
     _onAppIconHoverChanged: function() {
-        if (!this._dtpSettings.get_boolean('show-window-previews') || 
-            (!this.window && !this._nWindows)) {
+        if (this._dtpSettings.get_boolean('show-window-previews') || 
+            (this.window && this._nWindows)) {
+            this._openClosePreviewWindow(true);
             return;
         }
 
-        if (this.actor.hover) {
-            this._previewMenu.requestOpen(this);
-        } else {
-            this._previewMenu.requestClose();
+        if ((this._dtpSettings.get_string('click-action') == 'TOGGLE-SHOWPREVIEW') ||
+            (this._dtpSettings.get_string('shift-click-action') == 'TOGGLE-SHOWPREVIEW') ||
+            (this._dtpSettings.get_string('middle-click-action') == 'TOGGLE-SHOWPREVIEW') ||
+            (this._dtpSettings.get_string('shift-middle-click-action') == 'TOGGLE-SHOWPREVIEW')) {
+            // If opening, only allow opening of the preview window, if the preview window is already opened
+            // This is necessary in combination with the TOGGLE-SHOWPREVIEW action
+            this._openClosePreviewWindow(this._previewMenu.getOpenedState());
         }
+    },
+
+    /*
+    * Open (if allowed) or close the window overview
+    */    
+    _openClosePreviewWindow: function(allowOpening) {
+        if (this.actor.hover) {
+            if (allowOpening)
+                this._previewMenu.requestOpen(this);
+            else
+                return;
+        } else
+            this._previewMenu.requestClose();
     },
 
     _onDestroy: function() {
@@ -840,6 +857,9 @@ var taskbarAppIcon = Utils.defineClass({
                                     if(click_count > 1) {
                                         minimizeWindow(this.app, true, this._dtpSettings, monitor);
                                     }
+                                } else {
+                                    // Open the preview window
+                                    this._previewMenu.requestOpen(this);
                                 }
                             }
                         }

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -184,7 +184,8 @@ var PreviewMenu = Utils.defineClass({
 
             this._setReactive(true);
             this._setOpenedState(true);
-        }
+        } else
+            this.close();
     },
 
     close: function(immediate) {
@@ -275,6 +276,10 @@ var PreviewMenu = Utils.defineClass({
     _setOpenedState: function(opened) {
         this.opened = opened;
         this.emit('open-state-changed');
+    },
+
+    getOpenedState: function() {
+        return this.opened;
     },
 
     _removeFocus: function() {


### PR DESCRIPTION
Adds the possibility to activate preview windows only via the buttonAction "TOGGLE-SHOWEPREVIEW" without the need for having the global "show-window-previews" option enabled (however, this code correctly handles the situation correctly, if the flag is activated).

Additionally, when the preview window open/requestOpen method is called, the preview windows is closed IFF the passed appIcon is the same as the current icon. Having this behaviour, the window previews are closed when doing a buttonAction (e.g. click-action) on the appIcon for which window preview(s) are currently shown (IMO a usability improvement).

Fixes #696 