### PR TITLE
add workspacebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UUID = dash-to-panel@jderose9.github.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = appIcons.js convenience.js panel.js panelManager.js proximity.js intellihide.js panelStyle.js overview.js taskbar.js transparency.js windowPreview.js prefs.js update.js utils.js Settings.ui
+EXTRA_MODULES = appIcons.js convenience.js panel.js panelManager.js proximity.js intellihide.js panelStyle.js overview.js taskbar.js transparency.js workspaceSwitcher.js windowPreview.js prefs.js update.js utils.js Settings.ui
 EXTRA_IMAGES = highlight_stacked_bg.svg highlight_stacked_bg_2.svg highlight_stacked_bg_3.svg
 
 TOLOCALIZE =  prefs.js appIcons.js

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Additional credits: This extension leverages the work for [ZorinOS Taskbar](http
 Code to set anchor position taken from [Thoma5/gnome-shell-extension-bottompanel](https://github.com/Thoma5/gnome-shell-extension-bottompanel).
 Pattern for moving panel contents based on [Frippery Move Clock](http://frippery.org/extensions/) by R M Yorston.
 Ideas for recursing child actors and assigning inline styles are based on code from the extension [StatusAreaHorizontalSpacing](https://bitbucket.org/mathematicalcoffee/status-area-horizontal-spacing-gnome-shell-extension).
+The workspace switcher is based on the [Workspace Bar](https://github.com/mbokil/workspacebar) extension.
 ##
 
 #### Thanks to the following people for contributing via pull requests:

--- a/Settings.ui
+++ b/Settings.ui
@@ -5936,6 +5936,31 @@
                             <property name="top_attach">1</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkSwitch" id="show_workspace_switcher_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="show_workspace_switcher_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Show workspace switcher</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/panel.js
+++ b/panel.js
@@ -35,6 +35,7 @@ const Gi = imports._gi;
 const AppIcons = Me.imports.appIcons;
 const Utils = Me.imports.utils;
 const Taskbar = Me.imports.taskbar;
+const WorkspaceSwitcher = Me.imports.workspaceSwitcher;
 const PanelStyle = Me.imports.panelStyle;
 const Lang = imports.lang;
 const Main = imports.ui.main;
@@ -252,11 +253,14 @@ var dtpPanel = Utils.defineClass({
         });
         
         this.taskbar = new Taskbar.taskbar(this);
+        this.workspaceSwitcher = new WorkspaceSwitcher.WorkspaceSwitcher(this);
+
         Main.overview.dashIconSize = this.taskbar.iconSize;
 
         this.container.insert_child_above(this.taskbar.actor, null);
         
         this._setActivitiesButtonVisible(Me.settings.get_boolean('show-activities-button'));
+        this._setWorkspaceSwitcherVisible(Me.settings.get_boolean('show-workspace-switcher'));
         this._setAppmenuVisible(Me.settings.get_boolean('show-appmenu'));
         this._setClockLocation(Me.settings.get_string('location-clock'));
         this._displayShowDesktopButton(Me.settings.get_boolean('show-showdesktop-button'));
@@ -386,6 +390,7 @@ var dtpPanel = Utils.defineClass({
         this._signalsHandler.destroy();
         this.container.remove_child(this.taskbar.actor);
         this._setAppmenuVisible(false);
+        this._setWorkspaceSwitcherVisible(false);
 
         if (this.statusArea.appMenu) {
             setMenuArrow(this.statusArea.appMenu._arrow, St.Side.TOP);
@@ -422,6 +427,7 @@ var dtpPanel = Utils.defineClass({
         }
 
         this.taskbar.destroy();
+        this.workspaceSwitcher.destroy();
 
         // reset stored icon size  to the default dash
         Main.overview.dashIconSize = Main.overview._controls.dash.iconSize;
@@ -513,6 +519,11 @@ var dtpPanel = Utils.defineClass({
                 Me.settings,
                 'changed::show-activities-button',
                 () => this._setActivitiesButtonVisible(Me.settings.get_boolean('show-activities-button'))
+            ],
+            [
+                Me.settings,
+                'changed::show-workspace-switcher',
+                () => this._setWorkspaceSwitcherVisible(Me.settings.get_boolean('show-workspace-switcher'))
             ],
             [
                 Me.settings,
@@ -872,6 +883,18 @@ var dtpPanel = Utils.defineClass({
                 this.statusArea.activities.actor.hide();
     },
     
+    _setWorkspaceSwitcherVisible: function(isVisible) {
+        let parent = this.workspaceSwitcher.actor.get_parent();
+
+        if (parent) {
+            parent.remove_child(this.workspaceSwitcher.actor);
+        }
+
+        if (isVisible) {
+            this.container.insert_child_below(this.workspaceSwitcher.actor, this.taskbar.actor);
+        }
+    },
+
     _setAppmenuVisible: function(isVisible) {
         let parent;
         let appMenu = this.statusArea.appMenu;

--- a/prefs.js
+++ b/prefs.js
@@ -888,6 +888,11 @@ const Settings = new Lang.Class({
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
         
+        this._settings.bind('show-workspace-switcher',
+                            this._builder.get_object('show_workspace_switcher_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+
         this._builder.get_object('show_applications_side_padding_spinbutton').set_value(this._settings.get_int('show-apps-icon-side-padding'));
         this._builder.get_object('show_applications_side_padding_spinbutton').connect('value-changed', Lang.bind (this, function(widget) {
             this._settings.set_int('show-apps-icon-side-padding', widget.get_value());

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -350,6 +350,11 @@
       <summary>Show applications button</summary>
       <description>Show appplications button in the dash</description>
     </key>
+    <key type="b" name="show-workspace-switcher">
+      <default>false</default>
+      <summary>Show workspaces bar</summary>
+      <description>Show workspaces bar in the dash</description>
+    </key>
     <key type="s" name="show-apps-icon-file">
       <default>""</default>
       <summary>Custom Show Applications icon</summary>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -128,3 +128,20 @@
         color: rgba(256, 256, 256, 1);
         text-align: center;
 }
+
+#dashtopanelWorkspaceSwitcher {
+	margin: 0 8px;
+}
+
+#dashtopanelWorkspaceSwitcher .activeBtn,
+#dashtopanelWorkspaceSwitcher .inactiveBtn {
+	color: rgba(256, 256, 256, 1);
+	background-color: rgba(200, 200, 200, 1);
+	border: 1px solid #cccccc;
+	padding: 0 6px;
+}
+
+#dashtopanelWorkspaceSwitcher .inactiveBtn {
+	color: rgba(256, 256, 256, .5);
+	background-color: rgba(200, 200, 200, .5);
+}

--- a/utils.js
+++ b/utils.js
@@ -286,6 +286,15 @@ var getWorkspaceCount = function() {
     return DisplayWrapper.getWorkspaceManager().n_workspaces;
 };
 
+var activateWorkspaceByIndex = function(index) {
+    try {
+        getWorkspaceByIndex(index).activate(global.get_current_time());
+    } catch(e) {
+        global.logError(e);
+        return;
+    }
+};
+
 var checkIfWindowHasTransient = function(window) {
     let hasTransient;
 

--- a/workspaceSwitcher.js
+++ b/workspaceSwitcher.js
@@ -1,0 +1,167 @@
+/*
+ * This file is part of the Dash-To-Panel extension for Gnome 3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Credits:
+ * This file is based on code from the Workspace Bar extension by mbokil
+ * and the taskbar component (which is based on the Dash to Dock extension
+ * by micheleg, code from the Taskbar extension by Zorin OS and
+ * the upstream Gnome Shell source code).
+ */
+
+const Clutter = imports.gi.Clutter;
+const Gio = imports.gi.Gio;
+const Signals = imports.signals;
+const Lang = imports.lang;
+const St = imports.gi.St;
+
+const Main = imports.ui.main;
+const Workspace = imports.ui.workspace;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Me.imports.utils;
+const Panel = Me.imports.panel;
+
+
+var WSActor = Utils.defineClass({
+    Name: 'DashToPanel-WorkspaceSwitcherActor',
+    Extends: St.Widget,
+
+    _init: function(delegate) {
+        this._delegate = delegate;
+        this._currentBackgroundColor = 0;
+        this.callParent('_init', { name: 'dashtopanelWorkspaceSwitcher',
+                                   layout_manager: new Clutter.BoxLayout({ orientation: Clutter.Orientation[Panel.getOrientation().toUpperCase()] }),
+                                   clip_to_allocation: true });
+    }
+});
+
+
+var WorkspaceSwitcher = Utils.defineClass({
+    Name: 'DashToPanel.WorkspaceSwitcher',
+
+    _init : function(panel) {
+        this.panel = panel;
+        
+        this._signalsHandler = new Utils.GlobalSignalsHandler();
+
+        this._box = new St.BoxLayout({ vertical: false,
+                                       clip_to_allocation: false,
+                                       x_align: Clutter.ActorAlign.START,
+                                       y_align: Clutter.ActorAlign.START });
+
+        this._container = new WSActor(this);
+        this._container.add_actor(this._box);
+
+        let rtl = Clutter.get_default_text_direction() == Clutter.TextDirection.RTL;
+        this.actor = new St.Bin({ child: this._container,
+            y_align: St.Align.MIDDLE, x_align:rtl ? St.Align.END : St.Align.START
+        });
+
+        this._workId = Main.initializeDeferredWork(this._box, Lang.bind(this, this._redisplay));
+
+        this._signalsHandler.add(
+            [
+                this.panel,
+		[
+                    'notify::height',
+                    'notify::width',
+		],
+                () => this._queueRedisplay()
+            ],
+            [
+                Utils.DisplayWrapper.getWorkspaceManager(),
+                [
+                    'workspace-removed',
+                    'workspace-added',
+                    'workspace-switched'
+                ],
+                Lang.bind(this, this._redisplay)
+            ]
+        );
+    },
+
+    destroy: function() {
+        this._signalsHandler.destroy();
+        this._signalsHandler = 0;
+
+        this._container.destroy();
+    },
+
+    _queueRedisplay: function () {
+        Main.queueDeferredWork(this._workId);
+    },
+
+    _redisplay: function () {
+        if (!this._signalsHandler) {
+            return;
+        }
+        this._buildWorkspaceBtns();
+        this._box.queue_relayout();
+    },
+
+
+
+    _buildWorkspaceBtns: function() {
+        this._removeAllChildren(this._box); //clear box container
+        const workspaces = Utils.getWorkspaceCount() - 1;
+        const currentWorkspace = Utils.getCurrentWorkspace().index();
+        let str = '';
+
+        for (let x=0; x <= workspaces; x++) {
+            let str = (x+1).toString();
+            let label;		
+            if (x == currentWorkspace) {
+                label = new St.Label({ text: _(str), style_class: "activeBtn" });
+            } else {
+                label = new St.Label({ text: _(str), style_class: "inactiveBtn" });
+            }
+            
+            const button = new St.Button();
+            button.set_child(label);
+
+            button.connect('button-press-event', Lang.bind(this, function(actor, event) {
+                Utils.activateWorkspaceByIndex(actor.get_child().text - 1);
+            }));
+
+            button.connect('scroll-event', Lang.bind(this, this._onScrollEvent));
+            this._box.add_actor(button);
+        }
+    },
+
+    _removeAllChildren: function(box) {
+        let children = box.get_children();
+
+        if (children) {
+            let len = children.length;
+            for(let x=len-1; x >= 0; x--) {
+                box.remove_actor(children[x]);
+            }
+        }
+    },
+
+    _onScrollEvent : function(actor, event) {
+        let offset = Utils.getMouseScrollDirection(event) == 'up' ? -1 : 1;
+        let targetWorkspace = Utils.getCurrentWorkspace().index() + offset;
+        const workspaces = Utils.getWorkspaceCount() - 1;
+        if (targetWorkspace < 0) targetWorkspace = 0;
+        if (targetWorkspace > workspaces) targetWorkspace = workspaces;
+        Utils.activateWorkspaceByIndex(targetWorkspace);
+}
+});
+
+Signals.addSignalMethods(WorkspaceSwitcher.prototype);
+


### PR DESCRIPTION
I've implemented a more of less proof of concept of a workspace bar in order to fix #336. It's based on the Gnome extension [WorkspaceBar](https://extensions.gnome.org/extension/464/workspacebar/) which is not maintained anymore.

It does work so far, but of course, there are tons of possible enhancements:
- [ ] customize position (currently always left of the taskbar)
- [ ] customize colors (currently gray)
- [ ] customize size (or auto-size)
- [ ] multi-row display (if there is enough room)
- [ ] customize behavior: showing all workspaces (`1 2 3 4`) vs. current workspace only (`2 / 4` or just `2`)

### current features
- [x] show list of all workspaces
- [x] highlight active workspace
- [x] click on workspace switches to that workspace
- [x] scroll over items in order to switch workspace
- [x] setting for enable/disable workspace bar

![Screenshot](https://user-images.githubusercontent.com/6277619/65385936-2a0cd500-dd35-11e9-8287-8612028890a9.png)

![Settings](https://user-images.githubusercontent.com/6277619/65386369-1b292100-dd3b-11e9-8e12-3400112a726c.png)


What do you think about this? Could this be a good starting point for further development or did I made fundamental mistakes? (Honestly, I'm new to Gnome extensions development, so I may need some help :smile: )