### PR TITLE
fix error on Gnome 3.22.2

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -364,7 +364,7 @@ var dtpPanel = Utils.defineClass({
                     this._rightBox,
                     'notify::allocation',
                     () => this._refreshVerticalAlloc()
-                ],
+                ]
             );
         }
 
@@ -815,7 +815,7 @@ var dtpPanel = Utils.defineClass({
         return Clutter.EVENT_STOP;
     },
 
-    _getDraggableWindowForPosition(stageCoord, coord, dimension, maximizedProp) {
+    _getDraggableWindowForPosition: function(stageCoord, coord, dimension, maximizedProp) {
         let workspace = Utils.getCurrentWorkspace();
         let allWindowsByStacking = global.display.sort_windows_by_stacking(
             workspace.list_windows()


### PR DESCRIPTION
I'm using Gnome 3.22.2 (Debian 9). Here, the latest code on `master` fails with some syntax errors. This PR is a fix for this.