### PR TITLE
Fix CSS separators

### DIFF
--- a/windowPreview.js
+++ b/windowPreview.js
@@ -960,8 +960,8 @@ var Preview = Utils.defineClass({
     },
 
     _getBackgroundColor: function(offset, alpha) {
-        return 'background-color: ' + this._getRgbaColor(offset, alpha) + 
-               'transition-duration:' + this._previewMenu.panel.dynamicTransparency.animationDuration;
+        return 'background-color: ' + this._getRgbaColor(offset, alpha) +
+               'transition-duration:' + this._previewMenu.panel.dynamicTransparency.animationDuration + ';';
     },
 
     _getRgbaColor: function(offset, alpha) {


### PR DESCRIPTION
[GNOS GUI](https://gnos.in/gui) extensively uses dash-to-panel (custom config & styling).

While adapting latest release `stylesheet.css`, I found these CSS syntax errors preventing effective styling.

In the future, it would be great to provide a consistent way for styling, to avoid patching `stylesheet.css` and thus surviving updates, maybe dconf ?

Thank you for developing this great extension.