### PR TITLE
Update Hungarian translation

### DIFF
--- a/po/hu.po
+++ b/po/hu.po
@@ -6,9 +6,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: GitHub\n"
-"Report-Msgid-Bugs-To: https://github.com/jderose9/dash-to-panel/issues\n"
-"POT-Creation-Date: 2019-07-08 21:36+0200\n"
-"PO-Revision-Date: 2019-07-08 22:00+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/home-sweet-gnome/dash-to-panel/issues"
+"\n"
+"POT-Creation-Date: 2019-10-12 22:22+0200\n"
+"PO-Revision-Date: 2019-10-12 22:30+0200\n"
 "Last-Translator: Balázs Úr <ur.balazs at fsf dot hu>\n"
 "Language-Team: Hungarian\n"
 "Language: hu\n"
@@ -18,147 +19,288 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 18.12.3\n"
 
-#: prefs.js:310
+#: prefs.js:211
+msgid "Top, with plugin icons collapsed to bottom"
+msgstr "Fent, a bővítményikonokkal lent összecsukva"
+
+#: prefs.js:211
+msgid "Left, with plugin icons collapsed to right"
+msgstr "Balra, a bővítményikonokkal jobbra összecsukva"
+
+#: prefs.js:212
+msgid "Top, with fixed center plugin icons"
+msgstr "Fent, középen rögzített bővítményikonokkal"
+
+#: prefs.js:212
+msgid "Left, with fixed center plugin icons"
+msgstr "Balra, középen rögzített bővítményikonokkal"
+
+#: prefs.js:213
+msgid "Top, with floating center plugin icons"
+msgstr "Fent, középen lebegő bővítményikonokkal"
+
+#: prefs.js:213
+msgid "Left, with floating center plugin icons"
+msgstr "Balra, középen lebegő bővítményikonokkal"
+
+#: prefs.js:214
+msgid "Center, fixed in middle of monitor"
+msgstr "Középen, a kijelző közepén rögzítve"
+
+#: prefs.js:215
+msgid "Center, floating between top and bottom elements"
+msgstr "Középen, a fenti és lenti elemek között lebegve"
+
+#: prefs.js:215
+msgid "Center, floating between left and right elements"
+msgstr "Középen, a bal és jobb oldali elemek között lebegve"
+
+#: prefs.js:219
+msgid "Top of plugin icons"
+msgstr "A bővítményikonok fölött"
+
+#: prefs.js:219
+msgid "Left of plugin icons"
+msgstr "A bővítményikonoktól balra"
+
+#: prefs.js:220
+msgid "Bottom of plugin icons"
+msgstr "A bővítményikonok alatt"
+
+#: prefs.js:220
+msgid "Right of plugin icons"
+msgstr "A bővítményikonoktól jobbra"
+
+#: prefs.js:221
+msgid "Top of system indicators"
+msgstr "A rendszerjelzők fölött"
+
+#: prefs.js:221
+msgid "Left of system indicators"
+msgstr "A rendszerjelzőktől balra"
+
+#: prefs.js:222
+msgid "Bottom of system indicators"
+msgstr "A rendszerjelzők alatt"
+
+#: prefs.js:222
+msgid "Right of system indicators"
+msgstr "A rendszerjelzőktől jobbra"
+
+#: prefs.js:223
+msgid "Top of taskbar"
+msgstr "A feladatsáv fölött"
+
+#: prefs.js:223
+msgid "Left of taskbar"
+msgstr "A feladatsávtól balra"
+
+#: prefs.js:224
+msgid "Bottom of taskbar"
+msgstr "A feladatsáv alatt"
+
+#: prefs.js:224
+msgid "Right of taskbar"
+msgstr "A feladatsávtól jobbra"
+
+#: prefs.js:230
+msgid "Show Desktop button height (px)"
+msgstr "„Asztal megjelenítése” gomb magassága (képpont)"
+
+#: prefs.js:230
+msgid "Show Desktop button width (px)"
+msgstr "„Asztal megjelenítése” gomb szélessége (képpont)"
+
+#: prefs.js:364
 msgid "Running Indicator Options"
 msgstr "Futásjelző beállításai"
 
-#: prefs.js:317 prefs.js:515 prefs.js:658 prefs.js:778 prefs.js:842
-#: prefs.js:930 prefs.js:1023 prefs.js:1260 prefs.js:1344 prefs.js:1455
-#: prefs.js:1489 prefs.js:1531
+#: prefs.js:371 prefs.js:569 prefs.js:712 prefs.js:837 prefs.js:904
+#: prefs.js:992 prefs.js:1078 prefs.js:1325 prefs.js:1409 prefs.js:1474
+#: prefs.js:1510 prefs.js:1607 prefs.js:1641 prefs.js:1683
 msgid "Reset to defaults"
 msgstr "Visszaállítás az alapértékekre"
 
-#: prefs.js:460
+#: prefs.js:514
 msgid "Default (Primary monitor)"
 msgstr "Default (Elsődleges kijelző)"
 
-#: prefs.js:463
+#: prefs.js:517
 msgid "Monitor "
 msgstr "Kijelző"
 
-#: prefs.js:508
+#: prefs.js:562
 msgid "Multi-monitors options"
 msgstr "Többkijelzős beállítások"
 
-#: prefs.js:651
+#: prefs.js:705
 msgid "Dynamic opacity options"
 msgstr "Dinamikus átlátszatlansági beállítások"
 
-#: prefs.js:771
+#: prefs.js:830
 msgid "Intellihide options"
 msgstr "Intelligens elrejtés beállításai"
 
-#: prefs.js:835
+#: prefs.js:897
 msgid "Show Applications options"
 msgstr "„Alkalmazások megjelenítése” ikon beállításai"
 
-#: prefs.js:923
+#: prefs.js:985
 msgid "Show Desktop options"
 msgstr "„Asztal megjelenítése” gomb beállításai"
 
-#: prefs.js:1016
+#: prefs.js:1071
 msgid "Window preview options"
 msgstr "Ablakelőnézet beállításai"
 
-#: prefs.js:1253
+#: prefs.js:1318
 msgid "Ungrouped application options"
 msgstr "Nem csoportosított alkalmazás beállításai"
 
-#: prefs.js:1337
+#: prefs.js:1402
 msgid "Customize middle-click behavior"
 msgstr "Középső kattintás viselkedésének személyre szabása"
 
-#: prefs.js:1448
+#: prefs.js:1467
+msgid "Customize panel scroll behavior"
+msgstr "Panel görgetési viselkedésének személyre szabása"
+
+#: prefs.js:1503
+msgid "Customize icon scroll behavior"
+msgstr "Ikon görgetési viselkedésének személyre szabása"
+
+#: prefs.js:1600
 msgid "Advanced hotkeys options"
 msgstr "Speciális gyorsbillentyű-beállítások"
 
-#: prefs.js:1482
+#: prefs.js:1634
 msgid "Secondary Menu Options"
 msgstr "Másodlagos menü beállítások"
 
-#: prefs.js:1524 Settings.ui.h:216
+#: prefs.js:1676 Settings.ui.h:223
 msgid "Advanced Options"
 msgstr "Speciális beállítások"
 
-#: prefs.js:1611
+#: prefs.js:1763
 msgid "Export settings"
 msgstr "Beállítások exportálása"
 
-#: prefs.js:1628
+#: prefs.js:1780
 msgid "Import settings"
 msgstr "Beállítások importálása"
 
-#: appIcons.js:1287
+#: appIcons.js:1380
 msgid "Show Details"
 msgstr "Részletek megjelenítése"
 
-#: appIcons.js:1306
+#: appIcons.js:1398
 msgid "New Window"
 msgstr "Új ablak"
 
-#: appIcons.js:1306 appIcons.js:1368 appIcons.js:1370 Settings.ui.h:10
+#: appIcons.js:1398 appIcons.js:1458 appIcons.js:1460 Settings.ui.h:10
 msgid "Quit"
 msgstr "Kilépés"
 
-#: appIcons.js:1370
+#: appIcons.js:1460
 msgid "Windows"
 msgstr "Ablakok"
 
-#: appIcons.js:1578
+#: appIcons.js:1684
 msgid "Power options"
 msgstr "Energiabeállítások"
 
-#: appIcons.js:1583
+#: appIcons.js:1689
 msgid "Event logs"
 msgstr "Eseménynaplók"
 
-#: appIcons.js:1588
+#: appIcons.js:1694
 msgid "System"
 msgstr "Rendszer"
 
-#: appIcons.js:1593
+#: appIcons.js:1699
 msgid "Device Management"
 msgstr "Eszközkezelés"
 
-#: appIcons.js:1598
+#: appIcons.js:1704
 msgid "Disk Management"
 msgstr "Lemezkezelés"
 
-#: appIcons.js:1605
+#: appIcons.js:1711
 msgid "Terminal"
 msgstr "Terminál"
 
-#: appIcons.js:1610
+#: appIcons.js:1716
 msgid "System monitor"
 msgstr "Rendszerfigyelő"
 
-#: appIcons.js:1615
+#: appIcons.js:1721
 msgid "Files"
 msgstr "Fájlok"
 
-#: appIcons.js:1620
+#: appIcons.js:1726
 msgid "Settings"
 msgstr "Beállítások"
 
-#: appIcons.js:1627
+#: appIcons.js:1733
 msgid "Unlock taskbar"
 msgstr "Feladatsáv feloldása"
 
-#: appIcons.js:1627
+#: appIcons.js:1733
 msgid "Lock taskbar"
 msgstr "Feladatsáv zárolása"
 
-#: appIcons.js:1632
+#: appIcons.js:1738
 msgid "Dash to Panel Settings"
 msgstr "„Dashből panel” beállításai"
 
-#: appIcons.js:1639
+#: appIcons.js:1745
 msgid "Restore Windows"
 msgstr "Ablakok visszaállítása"
 
-#: appIcons.js:1639
+#: appIcons.js:1745
 msgid "Show Desktop"
 msgstr "Asztal megjelenítése"
+
+#: update.js:58
+#, javascript-format
+msgid "Version %s (%s) is available"
+msgstr "%s (%s) verzió érhető el"
+
+#: update.js:59
+msgid "Details"
+msgstr "Részletek"
+
+#: update.js:60
+msgid "Update"
+msgstr "Frissítés"
+
+#: update.js:63
+msgid "Already up to date"
+msgstr "Már naprakész"
+
+#: update.js:148
+msgid "Update successful, please log out/in"
+msgstr "Sikeres frissítés, jelentkezzen ki és be"
+
+#: update.js:149
+msgid "Log out"
+msgstr "Kijelentkezés"
+
+#: update.js:153
+msgid "Update successful, please restart GNOME Shell"
+msgstr "Sikeres frissítés, indítsa újra a GNOME Shell környezetet"
+
+#: update.js:154
+msgid "Restart GNOME Shell"
+msgstr "GNOME Shell újraindítása"
+
+#: update.js:154
+msgid "Restarting GNOME Shell..."
+msgstr "GNOME Shell újraindítása…"
+
+#: update.js:160
+msgid "Error: "
+msgstr "Hiba: "
 
 #: Settings.ui.h:1
 msgid "Nothing yet!"
@@ -412,168 +554,178 @@ msgid "Delay before hiding the panel (ms)"
 msgstr "Késleltetés a panel elrejtése előtt (ezredmásodperc)"
 
 #: Settings.ui.h:62
-msgid "Time (ms) before showing (100 is default)"
-msgstr "Megjelenítés előtti idő (ezredmásodperc, alapérték: 100)"
+msgid "Delay before enabling intellihide on start (ms)"
+msgstr ""
+"Az intelligens elrejtés indításkori engedélyezése előtti késleltetés "
+"(ezredmásodperc)"
 
 #: Settings.ui.h:63
-msgid "Time (ms) before hiding (100 is default)"
-msgstr "Elrejtés előtti idő (ezredmásodperc, alapértelmezetten 100)"
+msgid "Time (ms) before showing (100 is default)"
+msgstr "Megjelenítés előtti idő (ezredmásodperc, alapérték: 100)"
 
 #: Settings.ui.h:64
 msgid "Animation time (ms)"
 msgstr "Animáció ideje (ezredmásodperc)"
 
 #: Settings.ui.h:65
+msgid "Time (ms) before hiding (100 is default)"
+msgstr "Elrejtés előtti idő (ezredmásodperc, alapértelmezetten 100)"
+
+#: Settings.ui.h:66
+msgid "Immediate on application icon click"
+msgstr "Azonnal az alkalmazásikonra kattintáskor"
+
+#: Settings.ui.h:67
 msgid "Middle click on the preview to close the window"
 msgstr "Középső kattintás az előnézeten az ablak bezárásához"
 
-#: Settings.ui.h:66
+#: Settings.ui.h:68
 msgid "Window previews preferred size (px)"
 msgstr "Ablakelőnézetek előnyben részesített mérete (képpont)"
 
-#: Settings.ui.h:67
+#: Settings.ui.h:69
 msgid "Window previews aspect ratio Y (height)"
 msgstr "Ablakelőnézetek Y képaránya (magasság)"
 
-#: Settings.ui.h:68
+#: Settings.ui.h:70
 msgid "Window previews padding (px)"
 msgstr "Ablakelőnézetek kitöltése (képpont)"
 
-#: Settings.ui.h:69
+#: Settings.ui.h:71
 msgid "1"
 msgstr "1"
 
-#: Settings.ui.h:70
+#: Settings.ui.h:72
 msgid "2"
 msgstr "2"
 
-#: Settings.ui.h:71
+#: Settings.ui.h:73
 msgid "3"
 msgstr "3"
 
-#: Settings.ui.h:72
+#: Settings.ui.h:74
 msgid "4"
 msgstr "4"
 
-#: Settings.ui.h:73
+#: Settings.ui.h:75
 msgid "5"
 msgstr "5"
 
-#: Settings.ui.h:74
+#: Settings.ui.h:76
 msgid "6"
 msgstr "6"
 
-#: Settings.ui.h:75
+#: Settings.ui.h:77
 msgid "7"
 msgstr "7"
 
-#: Settings.ui.h:76
+#: Settings.ui.h:78
 msgid "8"
 msgstr "8"
 
-#: Settings.ui.h:77
+#: Settings.ui.h:79
 msgid "9"
 msgstr "9"
 
-#: Settings.ui.h:78
+#: Settings.ui.h:80
 msgid "10"
 msgstr "10"
 
-#: Settings.ui.h:79
+#: Settings.ui.h:81
 msgid "11"
 msgstr "11"
 
-#: Settings.ui.h:80
+#: Settings.ui.h:82
 msgid "12"
 msgstr "12"
 
-#: Settings.ui.h:81
+#: Settings.ui.h:83
 msgid "13"
 msgstr "13"
 
-#: Settings.ui.h:82
+#: Settings.ui.h:84
 msgid "14"
 msgstr "14"
 
-#: Settings.ui.h:83
+#: Settings.ui.h:85
 msgid "15"
 msgstr "15"
 
-#: Settings.ui.h:84
+#: Settings.ui.h:86
 msgid "16"
 msgstr "16"
 
-#: Settings.ui.h:85
+#: Settings.ui.h:87
 msgid "17"
 msgstr "17"
 
-#: Settings.ui.h:86
+#: Settings.ui.h:88
 msgid "18"
 msgstr "18"
 
-#: Settings.ui.h:87
+#: Settings.ui.h:89
 msgid "19"
 msgstr "19"
 
-#: Settings.ui.h:88
+#: Settings.ui.h:90
 msgid "20"
 msgstr "20"
 
-#: Settings.ui.h:89
+#: Settings.ui.h:91
 msgid "21"
 msgstr "21"
 
-#: Settings.ui.h:90
+#: Settings.ui.h:92
 msgid "Fixed"
 msgstr "Rögzített"
 
-#: Settings.ui.h:91
+#: Settings.ui.h:93
 msgid "Window previews aspect ratio X (width)"
 msgstr "Ablakelőnézetek X képaránya (szélesség)"
 
-#: Settings.ui.h:92
+#: Settings.ui.h:94
 msgid "Use custom opacity for the previews background"
 msgstr "Egyéni átlátszatlanság használata az előnézetek hátteréhez"
 
-#: Settings.ui.h:93
+#: Settings.ui.h:95
 msgid "If disabled, the previews background have the same opacity as the panel"
 msgstr ""
 "Ha le van tiltva, akkor az előnézetek háttere ugyanazzal az "
 "átlátszatlansággal rendelkezik mint a panel"
 
-#: Settings.ui.h:94
+#: Settings.ui.h:96
 msgid "Close button and header position"
 msgstr "Bezáró gomb és fejléc helyzete"
 
-#: Settings.ui.h:95
+#: Settings.ui.h:97
 msgid "Bottom"
 msgstr "Lent"
 
-#: Settings.ui.h:96
+#: Settings.ui.h:98
 msgid "Top"
 msgstr "Fent"
 
-#: Settings.ui.h:97
+#: Settings.ui.h:99
 msgid "Display window preview headers"
 msgstr "Ablakelőnézet fejléceinek megjelenítése"
 
-#: Settings.ui.h:98
+#: Settings.ui.h:100
 msgid "Font size (px) of the preview titles"
 msgstr "Az előnézet címeinek betűmérete (képpont)"
 
-#: Settings.ui.h:99
+#: Settings.ui.h:101
 msgid "Font weight of the preview titles"
 msgstr "Az előnézet címeinek betűvastagsága"
 
-#: Settings.ui.h:100
+#: Settings.ui.h:102
 msgid "Font color of the preview titles"
 msgstr "Az előnézet címeinek betűszíne"
 
-#: Settings.ui.h:101
+#: Settings.ui.h:103
 msgid "Enable window peeking"
 msgstr "Ablakbetekintés engedélyezése"
 
-#: Settings.ui.h:102
+#: Settings.ui.h:104
 msgid ""
 "When hovering over a window preview for some time, the window gets "
 "distinguished."
@@ -581,15 +733,15 @@ msgstr ""
 "Amikor rámutat egy ablakelőnézetre egy ideig, az ablak megkülönböztethetővé "
 "válik."
 
-#: Settings.ui.h:103
+#: Settings.ui.h:105
 msgid "Enter window peeking mode timeout (ms)"
 msgstr "Ablakbetekintési módba lépés időkorlátja (ezredmásodperc)"
 
-#: Settings.ui.h:104
+#: Settings.ui.h:106
 msgid "50"
 msgstr "50"
 
-#: Settings.ui.h:105
+#: Settings.ui.h:107
 msgid ""
 "Time of inactivity while hovering over a window preview needed to enter the "
 "window peeking mode."
@@ -597,15 +749,15 @@ msgstr ""
 "Egy ablakelőnézet rámutatása közbeni tétlenség ideje, amely az "
 "ablakbetekintési módba lépéshez szükséges."
 
-#: Settings.ui.h:106
+#: Settings.ui.h:108
 msgid "Window peeking mode opacity"
 msgstr "Ablakbetekintési módba átlátszatlansága"
 
-#: Settings.ui.h:107
+#: Settings.ui.h:109
 msgid "0"
 msgstr "0"
 
-#: Settings.ui.h:108
+#: Settings.ui.h:110
 msgid ""
 "All windows except for the peeked one have their opacity set to the same "
 "value."
@@ -613,40 +765,50 @@ msgstr ""
 "A betekintett ablak kivételével az összes ablaknál a saját átlátszatlanság "
 "ugyanarra az értékre van állítva."
 
-#: Settings.ui.h:109
+#: Settings.ui.h:111
+msgid "Delay between mouse scroll events (ms)"
+msgstr "Egérgörgetés-események közti késleltetés (ezredmásodperc)"
+
+#: Settings.ui.h:112
+msgid "Use this value to limit the number of captured mouse scroll events."
+msgstr ""
+"Használja ezt az értéket a rögzített egérgörgetés-események számának "
+"korlátozásához."
+
+#: Settings.ui.h:113
 msgid "Super"
 msgstr "Szuper"
 
-#: Settings.ui.h:110
+#: Settings.ui.h:114
 msgid "Super + Alt"
 msgstr "Szuper + Alt"
 
-#: Settings.ui.h:111
+#: Settings.ui.h:115
 msgid "Hotkeys prefix"
 msgstr "Gyorsbillentyű-előtag"
 
-#: Settings.ui.h:112
+#: Settings.ui.h:116
 msgid "Hotkeys will either be Super+Number or Super+Alt+Num"
 msgstr ""
 "A gyorsbillentyűk vagy Szuper + szám, vagy Szuper + Alt + szám lehetnek"
 
-#: Settings.ui.h:113
+#: Settings.ui.h:117
 msgid "Never"
 msgstr "Soha"
 
-#: Settings.ui.h:114
+#: Settings.ui.h:118
 msgid "Show temporarily"
 msgstr "Megjelenítés átmenetileg"
 
-#: Settings.ui.h:115
+#: Settings.ui.h:119
 msgid "Always visible"
 msgstr "Mindig látható"
 
-#: Settings.ui.h:116
+#: Settings.ui.h:120
 msgid "Number overlay"
 msgstr "Szám rátét"
 
-#: Settings.ui.h:117
+#: Settings.ui.h:121
 msgid ""
 "Temporarily show the application numbers over the icons when using the "
 "hotkeys."
@@ -654,154 +816,136 @@ msgstr ""
 "Az alkalmazás számainak átmeneti megjelenítése az ikonok fölött a "
 "gyorsbillentyűk használatakor."
 
-#: Settings.ui.h:118
+#: Settings.ui.h:122
 msgid "Hide timeout (ms)"
 msgstr "Elrejtési időkorlát (ezredmásodperc)"
 
-#: Settings.ui.h:119
+#: Settings.ui.h:123
 msgid "e.g. <Super>q"
 msgstr "például <Super>q"
 
-#: Settings.ui.h:120
+#: Settings.ui.h:124
 msgid "Shortcut to show the overlay for 2 seconds"
 msgstr "Gyorsbillentyű a rátét megjelenítéséhez 2 másodpercre"
 
-#: Settings.ui.h:121
+#: Settings.ui.h:125
 msgid "Show window previews on hotkey"
 msgstr "Ablakelőnézetek megjelenítése gyorsbillentyűvel"
 
-#: Settings.ui.h:122
+#: Settings.ui.h:126
 msgid "Show previews when the application have multiple instances"
 msgstr "Előnézetek megjelenítése, amikor az alkalmazásnak több példánya van"
 
-#: Settings.ui.h:123
+#: Settings.ui.h:127
+msgid "Number row"
+msgstr "Számsor"
+
+#: Settings.ui.h:128
+msgid "Numeric keypad"
+msgstr "Számbillentyűzet"
+
+#: Settings.ui.h:129
+msgid "Both"
+msgstr "Mindkettő"
+
+#: Settings.ui.h:130
+msgid "Hotkeys are activated with"
+msgstr "Gyorsbillentyűk bekapcsolva ezzel"
+
+#: Settings.ui.h:131
+msgid "Select which keyboard number keys are used to activate the hotkeys"
+msgstr ""
+"Annak kiválasztása, hogy a billentyűzet mely számbillentyűi legyenek "
+"használva a gyorsbillentyűk bekapcsolásához"
+
+#: Settings.ui.h:132
 msgid "Current Show Applications icon"
 msgstr "Jelenlegi „Alkalmazások megjelenítése” ikon"
 
-#: Settings.ui.h:124
+#: Settings.ui.h:133
 msgid "Select a Show Applications image icon"
 msgstr "Egy „Alkalmazások megjelenítése” képikon kiválasztása"
 
-#: Settings.ui.h:125
+#: Settings.ui.h:134
 msgid "Custom Show Applications image icon"
 msgstr "Egyéni „Alkalmazások megjelenítése” képikon"
 
-#: Settings.ui.h:126
+#: Settings.ui.h:135
 msgid "Show Applications icon side padding (px)"
 msgstr "„Alkalmazások megjelenítése” ikon oldalsó kitöltése (képpont)"
 
-#: Settings.ui.h:127
-msgid "Show Desktop button width (px)"
-msgstr "„Asztal megjelenítése” gomb szélessége (képpont)"
-
-#: Settings.ui.h:128
+#: Settings.ui.h:136
 msgid "Reveal the desktop when hovering the Show Desktop button"
 msgstr "Az asztal előhozása, ha az „Asztal megjelenítése” gombra mutat"
 
-#: Settings.ui.h:129
+#: Settings.ui.h:137
 msgid "Delay before revealing the desktop (ms)"
 msgstr "Késleltetés az asztal előhozása előtt (ezredmásodperc)"
 
-#: Settings.ui.h:130
+#: Settings.ui.h:138
 msgid "Fade duration (ms)"
 msgstr "Áttűnés időtartama (ezredmásodperc)"
 
-#: Settings.ui.h:131
+#: Settings.ui.h:139
 msgid "The panel background opacity is affected by"
 msgstr "A panel háttér-átlátszatlanságát a következő befolyásolja"
 
-#: Settings.ui.h:132
+#: Settings.ui.h:140
 msgid "Change opacity when a window gets closer than (px)"
 msgstr ""
 "Átlátszatlanság megváltoztatása, amikor egy ablak közelebb kerül mint "
 "(képpont)"
 
-#: Settings.ui.h:134
+#: Settings.ui.h:142
 #, no-c-format
 msgid "Change opacity to (%)"
 msgstr "Átlátszatlanság megváltoztatása erre (%)"
 
-#: Settings.ui.h:135
+#: Settings.ui.h:143
 msgid "Opacity change animation duration (ms)"
 msgstr "Átlátszatlanságváltozás animációjának időtartama (ezredmásodperc)"
 
-#: Settings.ui.h:136
+#: Settings.ui.h:144
 msgid "Panel screen position"
 msgstr "Panel képernyő-pozíciója"
 
-#: Settings.ui.h:137
+#: Settings.ui.h:145
+msgid "Left"
+msgstr "Bal"
+
+#: Settings.ui.h:146
+msgid "Right"
+msgstr "Jobb"
+
+#: Settings.ui.h:147
 msgid "Taskbar position"
 msgstr "Tálca helyzete"
 
-#: Settings.ui.h:138
-msgid "Left, with plugin icons collapsed to right"
-msgstr "Balra, a bővítményikonokkal jobbra összecsukva"
-
-#: Settings.ui.h:139
-msgid "Left, with fixed center plugin icons"
-msgstr "Balra, középen rögzített bővítményikonokkal"
-
-#: Settings.ui.h:140
-msgid "Left, with floating center plugin icons"
-msgstr "Balra, középen lebegő bővítményikonokkal"
-
-#: Settings.ui.h:141
-msgid "Center, fixed in middle of monitor"
-msgstr "Középen, a kijelző közepén rögzítve"
-
-#: Settings.ui.h:142
-msgid "Center, floating between left and right elements"
-msgstr "Középen, a bal és jobb oldali elemek között lebegve"
-
-#: Settings.ui.h:143
+#: Settings.ui.h:148
 msgid "Clock location"
 msgstr "Óra helye"
 
-#: Settings.ui.h:144
-msgid "Left of plugin icons"
-msgstr "A bővítményikonoktól balra"
-
-#: Settings.ui.h:145
-msgid "Right of plugin icons"
-msgstr "A bővítményikonoktól jobbra"
-
-#: Settings.ui.h:146
-msgid "Left of system indicators"
-msgstr "A rendszerjelzőktől balra"
-
-#: Settings.ui.h:147
-msgid "Right of system indicators"
-msgstr "A rendszerjelzőktől jobbra"
-
-#: Settings.ui.h:148
-msgid "Left of taskbar"
-msgstr "A feladatsávtól balra"
-
 #: Settings.ui.h:149
-msgid "Right of taskbar"
-msgstr "A feladatsávtól jobbra"
-
-#: Settings.ui.h:150
 msgid "Display the main panel on"
 msgstr "A főpanel megjelenítése ezen"
 
-#: Settings.ui.h:151
+#: Settings.ui.h:150
 msgid "Display panels on all monitors"
 msgstr "Panelek megjelenítése az összes kijelzőn"
 
-#: Settings.ui.h:152
+#: Settings.ui.h:151
 msgid "Panel Intellihide"
 msgstr "Panel intelligens elrejtése"
 
-#: Settings.ui.h:153
+#: Settings.ui.h:152
 msgid "Hide and reveal the panel according to preferences"
 msgstr "A panel elrejtése vagy előhozása a beállítások szerint"
 
-#: Settings.ui.h:154
+#: Settings.ui.h:153
 msgid "Position"
 msgstr "Pozíció"
 
-#: Settings.ui.h:155
+#: Settings.ui.h:154
 msgid ""
 "Panel Size\n"
 "(default is 48)"
@@ -809,7 +953,7 @@ msgstr ""
 "Panelméret\n"
 "(alapérték: 48)"
 
-#: Settings.ui.h:157
+#: Settings.ui.h:156
 msgid ""
 "App Icon Margin\n"
 "(default is 8)"
@@ -817,7 +961,7 @@ msgstr ""
 "Alkalmazásikon margó\n"
 "(alapérték: 8)"
 
-#: Settings.ui.h:159
+#: Settings.ui.h:158
 msgid ""
 "App Icon Padding\n"
 "(default is 4)"
@@ -825,135 +969,139 @@ msgstr ""
 "Alkalmazásikon térköz\n"
 "(alapérték: 4)"
 
-#: Settings.ui.h:161
+#: Settings.ui.h:160
 msgid "Running indicator position"
 msgstr "Futásjelző pozíciója"
 
-#: Settings.ui.h:162
+#: Settings.ui.h:161
 msgid "Running indicator style (Focused app)"
 msgstr "Futásjelző stílusa (kijelölt alkalmazás)"
 
-#: Settings.ui.h:163
+#: Settings.ui.h:162
 msgid "Dots"
 msgstr "Pontok"
 
-#: Settings.ui.h:164
+#: Settings.ui.h:163
 msgid "Squares"
 msgstr "Négyzetek"
 
-#: Settings.ui.h:165
+#: Settings.ui.h:164
 msgid "Dashes"
 msgstr "Szaggatott vonalak"
 
-#: Settings.ui.h:166
+#: Settings.ui.h:165
 msgid "Segmented"
 msgstr "Darabolt"
 
-#: Settings.ui.h:167
+#: Settings.ui.h:166
 msgid "Solid"
 msgstr "Tömör"
 
-#: Settings.ui.h:168
+#: Settings.ui.h:167
 msgid "Ciliora"
 msgstr "Ciliora"
 
-#: Settings.ui.h:169
+#: Settings.ui.h:168
 msgid "Metro"
 msgstr "Metro"
 
-#: Settings.ui.h:170
+#: Settings.ui.h:169
 msgid "Running indicator style (Unfocused apps)"
 msgstr "Futásjelző stílusa (nem kijelölt alkalmazások)"
 
-#: Settings.ui.h:171
+#: Settings.ui.h:170
 msgid "Override panel theme background color "
 msgstr "A paneltéma háttérszínének felülbírálása"
 
-#: Settings.ui.h:172
+#: Settings.ui.h:171
 msgid "Override panel theme background opacity"
 msgstr "A paneltéma háttér-átlátszatlanságának felülbírálása"
 
-#: Settings.ui.h:174
+#: Settings.ui.h:173
 #, no-c-format
 msgid "Panel background opacity (%)"
 msgstr "Panel háttér-átlátszatlansága (%)"
 
-#: Settings.ui.h:175
+#: Settings.ui.h:174
 msgid "Dynamic background opacity"
 msgstr "Dinamikus háttér-átlátszatlanság"
 
-#: Settings.ui.h:176
+#: Settings.ui.h:175
 msgid "Change opacity when a window gets close to the panel"
 msgstr ""
 "Átlátszatlanság megváltoztatása, amikor egy ablak közel kerül a panelhez"
 
-#: Settings.ui.h:177
+#: Settings.ui.h:176
 msgid "Override panel theme gradient "
 msgstr "A paneltéma színátmenetének felülbírálása"
 
-#: Settings.ui.h:179
+#: Settings.ui.h:178
 #, no-c-format
 msgid "Gradient top color and opacity (%)"
 msgstr "Színátmenet felső színe és átlátszatlansága (%)"
 
-#: Settings.ui.h:181
+#: Settings.ui.h:180
 #, no-c-format
 msgid "Gradient bottom color and opacity (%)"
 msgstr "Színátmenet alsó színe és átlátszatlansága (%)"
 
-#: Settings.ui.h:182
+#: Settings.ui.h:181
 msgid "Style"
 msgstr "Stílus"
 
-#: Settings.ui.h:183
+#: Settings.ui.h:182
 msgid "Show favorite applications"
 msgstr "Kedvenc alkalmazások megjelenítése"
 
-#: Settings.ui.h:184
+#: Settings.ui.h:183
 msgid "Show running applications"
 msgstr "Futó alkalmazások megjelenítése"
 
-#: Settings.ui.h:185
+#: Settings.ui.h:184
 msgid "Show <i>Applications</i> icon"
 msgstr "<i>Alkalmazások</i> ikon megjelenítése"
 
-#: Settings.ui.h:186
+#: Settings.ui.h:185
 msgid "Animate <i>Show Applications</i>."
 msgstr "<i>Alkalmazások megjelenítése</i> animálása."
 
-#: Settings.ui.h:187
+#: Settings.ui.h:186
 msgid "Show <i>Activities</i> button"
 msgstr "<i>Tevékenységek</i> gomb megjelenítése"
 
-#: Settings.ui.h:188
+#: Settings.ui.h:187
 msgid "Show <i>Desktop</i> button"
 msgstr "<i>Asztal</i> gomb megjelenítése"
 
-#: Settings.ui.h:189
+#: Settings.ui.h:188
 msgid "Show <i>AppMenu</i> button"
 msgstr "<i>Alkalmazásmenü</i> gomb megjelenítése"
 
-#: Settings.ui.h:190
+#: Settings.ui.h:189
 msgid "Top Bar > Show App Menu must be enabled in Tweak Tool"
 msgstr ""
 "A felső sáv > Alkalmazásmenü megjelenítésének engedélyezve kell mennie a "
 "finomhangoló eszközben"
 
-#: Settings.ui.h:191
+#: Settings.ui.h:190
 msgid "Show window previews on hover"
 msgstr "Ablakelőnézetek megjelenítése rámutatáskor"
 
-#: Settings.ui.h:192
+#: Settings.ui.h:191
 msgid "Show tooltip on hover"
 msgstr "Buboréksúgó megjelenítése rámutatáskor"
 
-#: Settings.ui.h:193
+#: Settings.ui.h:192
 msgid "Isolate Workspaces"
 msgstr "Munkaterületek elkülönítése"
 
-#: Settings.ui.h:194
+#: Settings.ui.h:193
 msgid "Ungroup applications"
 msgstr "Alkalmazások csoportosításának felbontása"
+
+#: Settings.ui.h:194
+msgid "Behavior"
+msgstr "Viselkedés"
 
 #: Settings.ui.h:195
 msgid "Behaviour when clicking on the icon of a running application."
@@ -968,6 +1116,34 @@ msgid "Toggle windows"
 msgstr "Ablakok átkapcsolása"
 
 #: Settings.ui.h:198
+msgid "Scroll panel action"
+msgstr "Panel görgetése művelet"
+
+#: Settings.ui.h:199
+msgid "Behavior when mouse scrolling over the panel."
+msgstr "Viselkedés, ha az egeret görgetik a panel fölött."
+
+#: Settings.ui.h:200
+msgid "Scroll icon action"
+msgstr "Ikon görgetése művelet"
+
+#: Settings.ui.h:201
+msgid "Behavior when mouse scrolling over an application icon."
+msgstr "Viselkedés, ha az egeret görgetik egy alkalmazásikon fölött."
+
+#: Settings.ui.h:202
+msgid "Do nothing"
+msgstr "Ne csináljon semmit"
+
+#: Settings.ui.h:203
+msgid "Switch workspace"
+msgstr "Munkaterület váltása"
+
+#: Settings.ui.h:204
+msgid "Cycle windows"
+msgstr "Ablakok léptetése"
+
+#: Settings.ui.h:205
 msgid ""
 "Enable Super+(0-9) as shortcuts to activate apps. It can also be used "
 "together with Shift and Ctrl."
@@ -975,15 +1151,15 @@ msgstr ""
 "Szuper + (0-9) engedélyezése gyorsbillentyűként az alkalmazások "
 "aktiválásához. Használható a Shift és a Ctrl billentyűkkel együtt is."
 
-#: Settings.ui.h:199
+#: Settings.ui.h:206
 msgid "Use hotkeys to activate apps"
 msgstr "Gyorsbillentyűk használata az alkalmazások aktiválásához"
 
-#: Settings.ui.h:200
-msgid "Behavior"
-msgstr "Viselkedés"
+#: Settings.ui.h:207
+msgid "Action"
+msgstr "Művelet"
 
-#: Settings.ui.h:201
+#: Settings.ui.h:208
 msgid ""
 "Tray Font Size\n"
 "(0 = theme default)"
@@ -991,7 +1167,7 @@ msgstr ""
 "Tálca betűmérete\n"
 "(0 = téma alapértéke)"
 
-#: Settings.ui.h:203
+#: Settings.ui.h:210
 msgid ""
 "LeftBox Font Size\n"
 "(0 = theme default)"
@@ -999,7 +1175,7 @@ msgstr ""
 "Bal doboz betűmérete\n"
 "(0 = téma alapértéke)"
 
-#: Settings.ui.h:205
+#: Settings.ui.h:212
 msgid ""
 "Tray Item Padding\n"
 "(-1 = theme default)"
@@ -1007,7 +1183,7 @@ msgstr ""
 "Tálcaelem kitöltése\n"
 "(-1 = téma alapértéke)"
 
-#: Settings.ui.h:207
+#: Settings.ui.h:214
 msgid ""
 "Status Icon Padding\n"
 "(-1 = theme default)"
@@ -1015,7 +1191,7 @@ msgstr ""
 "Állapotikon kitöltése\n"
 "(-1 = téma alapértéke)"
 
-#: Settings.ui.h:209
+#: Settings.ui.h:216
 msgid ""
 "LeftBox Padding\n"
 "(-1 = theme default)"
@@ -1023,39 +1199,39 @@ msgstr ""
 "Bal doboz kitöltése\n"
 "(-1 = téma alapértéke)"
 
-#: Settings.ui.h:211
+#: Settings.ui.h:218
 msgid "Animate switching applications"
 msgstr "Alkalmazásváltások animálása"
 
-#: Settings.ui.h:212
+#: Settings.ui.h:219
 msgid "Animate launching new windows"
 msgstr "Új ablakok indításának animálása"
 
-#: Settings.ui.h:213
+#: Settings.ui.h:220
 msgid "Keep original gnome-shell dash (overview)"
 msgstr "Eredeti gnome-shell dash megtartása (áttekintő)"
 
-#: Settings.ui.h:214
+#: Settings.ui.h:221
 msgid "Activate panel menu buttons (e.g. date menu) on click only"
 msgstr "Panelmenü gombjainak (például dátum menü) aktiválása csak kattintáskor"
 
-#: Settings.ui.h:215
+#: Settings.ui.h:222
 msgid "App icon secondary (right-click) menu"
 msgstr "Alkalmazásikon másodlagos (jobb kattintásos) menüje"
 
-#: Settings.ui.h:217
+#: Settings.ui.h:224
 msgid "Fine-Tune"
 msgstr "Finomhangolás"
 
-#: Settings.ui.h:218
+#: Settings.ui.h:225
 msgid "version: "
 msgstr "verzió: "
 
-#: Settings.ui.h:219
+#: Settings.ui.h:226
 msgid "GitHub"
 msgstr "GitHub"
 
-#: Settings.ui.h:220
+#: Settings.ui.h:227
 msgid ""
 "Use the buttons below to create a settings file from your current "
 "preferences that can be imported on a different machine."
@@ -1063,19 +1239,48 @@ msgstr ""
 "Használja a lenti gombokat egy beállítási fájl létrehozásához a jelenlegi "
 "beállításokból, amely importálható egy másik gépen."
 
-#: Settings.ui.h:221
+#: Settings.ui.h:228
 msgid "Export and import settings"
 msgstr "Beállítások exportálása és importálása"
 
-#: Settings.ui.h:222
+#: Settings.ui.h:229
 msgid "Export to file"
 msgstr "Exportálás fájlba"
 
-#: Settings.ui.h:223
+#: Settings.ui.h:230
 msgid "Import from file"
 msgstr "Importálás fájlból"
 
-#: Settings.ui.h:224
+#: Settings.ui.h:231
+msgid ""
+"This allows you to update the extension directly from the GitHub repository."
+msgstr ""
+"Ez lehetővé teszi a kiterjesztés frissítést közvetlenül a GitHub tárolóból."
+
+#: Settings.ui.h:232
+msgid "Updates"
+msgstr "Frissítések"
+
+#: Settings.ui.h:233
+msgid "Periodically check for updates"
+msgstr "Frissítések rendszeres ellenőrzése"
+
+#: Settings.ui.h:234
+msgid "Check now"
+msgstr "Ellenőrzés most"
+
+#: Settings.ui.h:235
+msgid ""
+"<span weight=\"bold\" color=\"#B42B30\">Be aware, these official Dash to "
+"Panel releases might not be reviewed yet on extensions.gnome.org!</span>  <a "
+"href=\"https://extensions.gnome.org/about/\">Read more</a>"
+msgstr ""
+"<span weight=\"bold\" color=\"#B42B30\">Ne feledje, hogy ezeket a hivatalos "
+"„Dash to Panel” kiterjesztéseket esetleg még nem vizsgálták felül az "
+"extensions.gnome.org oldalon!</span>  <a "
+"href=\"https://extensions.gnome.org/about/\">Tudjon meg többet</a>"
+
+#: Settings.ui.h:236
 msgid ""
 "<span size=\"small\">This program comes with ABSOLUTELY NO WARRANTY.\n"
 "See the <a href=\"https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
@@ -1086,6 +1291,6 @@ msgstr ""
 "\">GNU General Public License 2. vagy későbbi verzióját</a> a részletekért.<"
 "/span>"
 
-#: Settings.ui.h:226
+#: Settings.ui.h:238
 msgid "About"
 msgstr "Névjegy"


### PR DESCRIPTION
Here is the updated Hungarian translation for v24 as requested in https://github.com/home-sweet-gnome/dash-to-panel/issues/756.