### PR TITLE
Updated proximity for windows that are either focused or maxed.

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1757,6 +1757,7 @@
                               <item id="ALL_WINDOWS" translatable="yes">All windows</item>
                               <item id="FOCUSED_WINDOWS" translatable="yes">Focused windows</item>
                               <item id="MAXIMIZED_WINDOWS" translatable="yes">Maximized windows</item>
+                              <item id="FOCUSED_OR_MAXIMIZED_WINDOWS" translatable="yes">Focused or maximized windows</item>
                             </items>
                           </object>
                           <packing>
@@ -4211,6 +4212,7 @@
                       <item id="ALL_WINDOWS" translatable="yes">All windows</item>
                       <item id="FOCUSED_WINDOWS" translatable="yes">Focused windows</item>
                       <item id="MAXIMIZED_WINDOWS" translatable="yes">Maximized windows</item>
+                      <item id="FOCUSED_OR_MAXIMIZED_WINDOWS" translatable="yes">Focused or maximized windows</item>
                     </items>
                   </object>
                   <packing>

--- a/proximity.js
+++ b/proximity.js
@@ -33,7 +33,8 @@ const T1 = 'limitUpdateTimeout';
 var Mode = {
     ALL_WINDOWS: 0,
     FOCUSED_WINDOWS: 1,
-    MAXIMIZED_WINDOWS: 2
+    MAXIMIZED_WINDOWS: 2,
+    FOCUSED_OR_MAXIMIZED_WINDOWS: 3,
 };
 
 var ProximityWatch = Utils.defineClass({
@@ -245,6 +246,13 @@ var ProximityManager = Utils.defineClass({
         } else if (watch.mode === Mode.MAXIMIZED_WINDOWS) {
             return metaWindows.some(mw => mw.maximized_vertically && mw.maximized_horizontally && 
                                           mw.get_monitor() == watch.monitorIndex);
+        } else if (watch.mode === Mode.FOCUSED_OR_MAXIMIZED_WINDOWS) {
+            let is_focused = (this._focusedWindowInfo &&
+                    this._checkIfHandledWindow(this._focusedWindowInfo.metaWindow) &&
+                    this._checkProximity(this._focusedWindowInfo.metaWindow, watch));
+            let is_maximized = metaWindows.some(mw => mw.maximized_vertically && mw.maximized_horizontally &&
+                                          mw.get_monitor() == watch.monitorIndex);
+            return is_focused || is_maximized;
         }
         
         //Mode.ALL_WINDOWS

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -57,6 +57,7 @@
     <value value='0' nick='ALL_WINDOWS'/>
     <value value='1' nick='FOCUSED_WINDOWS'/>
     <value value='2' nick='MAXIMIZED_WINDOWS'/>
+    <value value='3' nick='FOCUSED_OR_MAXIMIZED_WINDOWS'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-panel.fontWeight'>
     <value value='0' nick='inherit'/>


### PR DESCRIPTION
Allowed users to choose to hide bar in both focused and maximized windows in intellihide settings.

Reason: Very useful when multi-monitor user is watching a movie / video in a maximized window while working on a task in a focused window that happens to be at the bottom corner of another monitor.

Previously, if the user had selected to hide bar in focused windows, the bottom part of the movie / video will be hidden (since it's not focused) - and if the user had selected to hide bar in maximized windows, part of the active window he's working on will be hidden under the bar since it's not maximized.