### PR TITLE
Add "highest window per monitor" option to intellihide

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1757,6 +1757,7 @@
                               <item id="ALL_WINDOWS" translatable="yes">All windows</item>
                               <item id="FOCUSED_WINDOWS" translatable="yes">Focused windows</item>
                               <item id="MAXIMIZED_WINDOWS" translatable="yes">Maximized windows</item>
+                              <item id="HIGHEST_WINDOW_PER_MONITOR" translatable="yes">Highest window per monitor</item>
                             </items>
                           </object>
                           <packing>

--- a/proximity.js
+++ b/proximity.js
@@ -33,7 +33,8 @@ const T1 = 'limitUpdateTimeout';
 var Mode = {
     ALL_WINDOWS: 0,
     FOCUSED_WINDOWS: 1,
-    MAXIMIZED_WINDOWS: 2
+    MAXIMIZED_WINDOWS: 2,
+    HIGHEST_WINDOW_PER_MONITOR: 3
 };
 
 var ProximityWatch = Utils.defineClass({
@@ -238,7 +239,18 @@ var ProximityManager = Utils.defineClass({
     },
 
     _update: function(watch, metaWindows) {
-        if (watch.mode === Mode.FOCUSED_WINDOWS) {
+        if (watch.mode === Mode.HIGHEST_WINDOW_PER_MONITOR) {
+            if(metaWindows.length < 1) {
+                return false;
+            }
+            for (var i = metaWindows.length - 1; i >= 0; i--){
+                var mw = metaWindows[i];
+                if(mw.get_monitor() == watch.monitorIndex) {
+                    return this._checkProximity(mw, watch);
+                }
+            }
+            return false;
+        } else if (watch.mode === Mode.FOCUSED_WINDOWS) {
             return (this._focusedWindowInfo && 
                     this._checkIfHandledWindow(this._focusedWindowInfo.metaWindow) &&
                     this._checkProximity(this._focusedWindowInfo.metaWindow, watch));

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -57,6 +57,7 @@
     <value value='0' nick='ALL_WINDOWS'/>
     <value value='1' nick='FOCUSED_WINDOWS'/>
     <value value='2' nick='MAXIMIZED_WINDOWS'/>
+    <value value='3' nick='HIGHEST_WINDOW_PER_MONITOR'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-panel.fontWeight'>
     <value value='0' nick='inherit'/>


### PR DESCRIPTION
This pull request adds a "Highest window per Monitor" option to intellihide, which replicates the behaviour of Dash-to-dock's intellihide, and only hides when obstructed by the top window on the monitor