### PR TITLE
Add intellihide-respond-to-mouse option

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -1776,11 +1776,12 @@
               </object>
             </child>
             <child>
-              <object class="GtkListBoxRow" id="listboxrow_intellihide_pressure">
+              <object class="GtkListBoxRow" id="listboxrow_intellihide_respond_to_mouse">
+                <property name="width_request">100</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <child>
-                  <object class="GtkGrid" id="grid_intellihide_pressure">
+                  <object class="GtkGrid" id="grid_intellihide_respond_to_mouse">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="margin_left">12</property>
@@ -1790,11 +1791,11 @@
                     <property name="row_spacing">12</property>
                     <property name="column_spacing">32</property>
                     <child>
-                      <object class="GtkLabel" id="intellihide_use_pressure_label">
+                      <object class="GtkLabel" id="intellihide_respond_to_mouse_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Require pressure at the edge of the screen to reveal the panel</property>
+                        <property name="label" translatable="yes">The mouse can be used to reveal the panel</property>
                         <property name="use_markup">True</property>
                         <property name="xalign">0</property>
                       </object>
@@ -1804,7 +1805,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkSwitch" id="intellihide_use_pressure_switch">
+                      <object class="GtkSwitch" id="intellihide_respond_to_mouse_switch">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="halign">end</property>
@@ -1815,18 +1816,28 @@
                         <property name="top_attach">0</property>
                       </packing>
                     </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow" id="listboxrow_intellihide_pressure">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
                     <child>
-                      <object class="GtkGrid" id="intellihide_use_pressure_options">
+                      <object class="GtkGrid" id="grid_intellihide_pressure">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="margin_left">12</property>
-                        <property name="row_spacing">4</property>
+                        <property name="margin_right">12</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="row_spacing">12</property>
+                        <property name="column_spacing">32</property>
                         <child>
-                          <object class="GtkLabel" id="intellihide_pressure_threshold_label">
+                          <object class="GtkLabel" id="intellihide_use_pressure_label">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="hexpand">True</property>
-                            <property name="label" translatable="yes">Required pressure threshold (px)</property>
+                            <property name="label" translatable="yes">Require pressure at the edge of the screen to reveal the panel</property>
                             <property name="use_markup">True</property>
                             <property name="xalign">0</property>
                           </object>
@@ -1836,14 +1847,11 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkSpinButton" id="intellihide_pressure_threshold_spinbutton">
+                          <object class="GtkSwitch" id="intellihide_use_pressure_switch">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="halign">end</property>
-                            <property name="width_chars">4</property>
-                            <property name="text">0</property>
-                            <property name="adjustment">intellihide_pressure_threshold_adjustment</property>
-                            <property name="numeric">True</property>
+                            <property name="valign">center</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -1851,40 +1859,77 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="intellihide_pressure_time_label">
+                          <object class="GtkGrid" id="intellihide_use_pressure_options">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="hexpand">True</property>
-                            <property name="label" translatable="yes">Required pressure timeout (ms)</property>
-                            <property name="use_markup">True</property>
-                            <property name="xalign">0</property>
+                            <property name="margin_left">12</property>
+                            <property name="row_spacing">4</property>
+                            <child>
+                              <object class="GtkLabel" id="intellihide_pressure_threshold_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="label" translatable="yes">Required pressure threshold (px)</property>
+                                <property name="use_markup">True</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="intellihide_pressure_threshold_spinbutton">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="width_chars">4</property>
+                                <property name="text">0</property>
+                                <property name="adjustment">intellihide_pressure_threshold_adjustment</property>
+                                <property name="numeric">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="intellihide_pressure_time_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="label" translatable="yes">Required pressure timeout (ms)</property>
+                                <property name="use_markup">True</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="intellihide_pressure_time_spinbutton">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="width_chars">4</property>
+                                <property name="text">0</property>
+                                <property name="adjustment">intellihide_pressure_time_adjustment</property>
+                                <property name="numeric">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
                             <property name="top_attach">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSpinButton" id="intellihide_pressure_time_spinbutton">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="halign">end</property>
-                            <property name="width_chars">4</property>
-                            <property name="text">0</property>
-                            <property name="adjustment">intellihide_pressure_time_adjustment</property>
-                            <property name="numeric">True</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">1</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
-                        <property name="width">2</property>
-                      </packing>
                     </child>
                   </object>
                 </child>

--- a/prefs.js
+++ b/prefs.js
@@ -765,6 +765,11 @@ const Settings = new Lang.Class({
                             'active-id',
                             Gio.SettingsBindFlags.DEFAULT);
 
+        this._settings.bind('intellihide-respond-to-mouse',
+                            this._builder.get_object('intellihide_respond_to_mouse_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+
         this._settings.bind('intellihide-use-pressure',
                             this._builder.get_object('intellihide_use_pressure_switch'),
                             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -296,6 +296,11 @@
       <summary>Intellihide behaviour</summary>
       <description>Dictates how to intelligently hide the panel</description>
     </key>
+    <key type="b" name="intellihide-respond-to-mouse">
+      <default>true</default>
+      <summary>Intellihide responds to mouse</summary>
+      <description>The mouse can be used to reveal the panel.</description>
+    </key>
     <key type="b" name="intellihide-use-pressure">
       <default>false</default>
       <summary>Intellihide pressure</summary>


### PR DESCRIPTION
Add option to make intellihide ignore the mouse completely. 

Implements #815 in a rather heavy-handed way, just making every reference to anything mouse-related check a configuration option first.