### PR TITLE
Tweak default appicon-padding

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -675,7 +675,7 @@
         <description>Set the margin for application icons in the embedded dash.</description>
     </key>
     <key type="i" name="appicon-padding">
-        <default>4</default>
+        <default>8</default>
         <summary>App icon padding</summary>
         <description>Set the padding for application icons in the embedded dash.</description>
     </key>


### PR DESCRIPTION
This new default padding provides appicons a more consistent look with dash-to-dock, and Windows.