### PR TITLE
Fix syntax errors

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -566,7 +566,7 @@ var dtpPanel = Utils.defineClass({
                 Me.settings,
                 'changed::progress-show-count',
                 () => this._initProgressManager()
-            ],
+            ]
         );
 
         if (isVertical) {

--- a/progress.js
+++ b/progress.js
@@ -104,7 +104,7 @@ var ProgressManager = Utils.defineClass({
         this.emit('progress-entry-removed', entry);
     },
 
-    _acquireUnityDBus() {
+    _acquireUnityDBus: function() {
         if (!this._unity_bus_id) {
             Gio.DBus.session.own_name('com.canonical.Unity',
                 Gio.BusNameOwnerFlags.ALLOW_REPLACEMENT, null, null);


### PR DESCRIPTION
Resolves the syntax errors found on Debian 9 with GNOME 3.22.2 reported in #885.