### PR TITLE
AppsIcon Menu only shows existing apps

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1740,19 +1740,10 @@ var MyShowAppsIconMenu = Utils.defineClass({
 
     _dtpRedisplay: function() {
         this.removeAll();
-
-        // true if `which` can find the app
-        function _checkExists(app) {
-            let cmd = "which '" + app + "'";
-            let out = GLib.spawn_command_line_sync(cmd);
-
-            // out contains 1: stdout, 2: stderr, 3: exit code
-            return out[3] == 0;
-        }
-
+        
         // Only add menu entries for commands that exist in path
         function _appendItem(obj, info) {
-            if (_checkExists(info.cmd[0])) {
+            if (Utils.checkExists(info.cmd[0])) {
                 let item = obj._appendMenuItem(_(info.title));
 
                 item.connect('activate', function() {
@@ -1765,27 +1756,27 @@ var MyShowAppsIconMenu = Utils.defineClass({
         }
 
         if (this.sourceActor != Main.layoutManager.dummyCursor) {
-            let powerSettingsMenuItem = _appendItem(this, {
+            _appendItem(this, {
                 title: 'Power options',
                 cmd: ['gnome-control-center', 'power']
             });
 
-            let logsMenuItem = _appendItem(this, {
+            _appendItem(this, {
                 title: 'Event logs',
                 cmd: ['gnome-logs']
             });
 
-            let systemSettingsMenuItem = _appendItem(this, {
+            _appendItem(this, {
                 title: 'System',
                 cmd: ['gnome-control-center', 'info-overview']
             });
 
-            let devicesSettingsMenuItem = _appendItem(this, {
+            _appendItem(this, {
                 title: 'Device Management',
                 cmd: ['gnome-control-center', 'display']
             });
 
-            let disksMenuItem = _appendItem(this, {
+            _appendItem(this, {
                 title: 'Disk Management',
                 cmd: ['gnome-disks']
             });
@@ -1793,27 +1784,27 @@ var MyShowAppsIconMenu = Utils.defineClass({
             this._appendSeparator();
         }
 
-        let terminalMenuItem = _appendItem(this, {
+        _appendItem(this, {
             title: 'Terminal',
             cmd: ['gnome-terminal']
         });
 
-        let systemMonitorMenuItem = _appendItem(this, {
+        _appendItem(this, {
             title: 'System monitor',
             cmd: ['gnome-system-monitor']
         });
 
-        let filesMenuItem = _appendItem(this, {
+        _appendItem(this, {
             title: 'Files',
             cmd: ['nautilus']
         });
 
-        let extPrefsMenuItem = _appendItem(this, {
+        _appendItem(this, {
             title: 'Extensions',
             cmd: ['gnome-shell-extension-prefs']
         });
 
-        let gsSettingsMenuItem = _appendItem(this, {
+        _appendItem(this, {
             title: 'Settings',
             cmd: ['gnome-control-center', 'wifi']
         });

--- a/appIcons.js
+++ b/appIcons.js
@@ -1741,59 +1741,84 @@ var MyShowAppsIconMenu = Utils.defineClass({
     _dtpRedisplay: function() {
         this.removeAll();
 
-        if (this.sourceActor != Main.layoutManager.dummyCursor) { 
-            let powerSettingsMenuItem = this._appendMenuItem(_('Power options'));
-            powerSettingsMenuItem.connect('activate', function () {
-                Util.spawn(['gnome-control-center', 'power']);
+        function _checkExists(app) {
+            let cmd = "which '" + app + "'";
+            let out = GLib.spawn_command_line_sync(cmd);
+
+            // out contains 1: stdout, 2: stderr, 3: exit code
+            return out[3] == 0;
+        }
+
+        function _appendItem(obj, info) {
+            if (_checkExists(info.cmd[0])) {
+                let item = obj._appendMenuItem(_(info.title));
+
+                item.connect('activate', function() {
+                    Util.spawn(info.cmd);
+                });
+
+                log("    FOUND: " + info.cmd[0]);
+                return item;
+            } else {
+                log("NOT FOUND: " + info.cmd[0]);
+            }
+
+            return null;
+        }
+
+        if (this.sourceActor != Main.layoutManager.dummyCursor) {
+            let powerSettingsMenuItem = _appendItem(this, {
+                title: 'Power options',
+                cmd: ['gnome-control-center', 'power']
             });
 
-            let logsMenuItem = this._appendMenuItem(_('Event logs'));
-            logsMenuItem.connect('activate', function () {
-                Util.spawn(['gnome-logs']);
+            let logsMenuItem = _appendItem(this, {
+                title: 'Event logs',
+                cmd: ['gnome-logs']
             });
 
-            let systemSettingsMenuItem = this._appendMenuItem(_('System'));
-            systemSettingsMenuItem.connect('activate', function () {
-                Util.spawn(['gnome-control-center', 'info-overview']);
+            let systemSettingsMenuItem = _appendItem(this, {
+                title: 'System',
+                cmd: ['gnome-control-center', 'info-overview']
             });
 
-            let devicesSettingsMenuItem = this._appendMenuItem(_('Device Management'));
-            devicesSettingsMenuItem.connect('activate', function () {
-                Util.spawn(['gnome-control-center', 'display']);
+            let devicesSettingsMenuItem = _appendItem(this, {
+                title: 'Device Management',
+                cmd: ['gnome-control-center', 'display']
             });
 
-            let disksMenuItem = this._appendMenuItem(_('Disk Management'));
-            disksMenuItem.connect('activate', function () {
-                Util.spawn(['gnome-disks']);
+            let disksMenuItem = _appendItem(this, {
+                title: 'Disk Management',
+                cmd: ['gnome-disks']
             });
 
             this._appendSeparator();
         }
 
-        let terminalMenuItem = this._appendMenuItem(_('Terminal'));
-        terminalMenuItem.connect('activate', function () {
-            Util.spawn(['gnome-terminal']);
+        let terminalMenuItem = _appendItem(this, {
+            title: 'Terminal',
+            cmd: ['gnome-terminal']
         });
 
-        let systemMonitorMenuItem = this._appendMenuItem(_('System monitor'));
-        systemMonitorMenuItem.connect('activate', function () {
-            Util.spawn(['gnome-system-monitor']);
+        let systemMonitorMenuItem = _appendItem(this, {
+            title: 'System monitor',
+            cmd: ['gnome-system-monitor']
         });
 
-        let filesMenuItem = this._appendMenuItem(_('Files'));
-        filesMenuItem.connect('activate', function () {
-            Util.spawn(['nautilus']);
+        let filesMenuItem = _appendItem(this, {
+            title: 'Files',
+            cmd: ['nautilus']
         });
 
-        let extPrefsMenuItem = this._appendMenuItem(_('Extensions'));
-        extPrefsMenuItem.connect('activate', function () {
-            Util.spawn(["gnome-shell-extension-prefs"]);
+        let extPrefsMenuItem = _appendItem(this, {
+            title: 'Extensions',
+            cmd: ['gnome-shell-extension-prefs']
         });
 
-        let gsSettingsMenuItem = this._appendMenuItem(_('Settings'));
-        gsSettingsMenuItem.connect('activate', function () {
-            Util.spawn(['gnome-control-center', 'wifi']);
-        });     
+        let gsSettingsMenuItem = _appendItem(this, {
+            title: 'Settings',
+            cmd: ['gnome-control-center', 'wifi']
+        });
 
         this._appendSeparator();
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -1754,62 +1754,34 @@ var MyShowAppsIconMenu = Utils.defineClass({
 
             return null;
         }
+        
+        function _appendList(obj, cmd_list, title_list) {
+            if (cmd_list.length != title_list.length) {
+                return;
+            }
+            
+            for (var entry = 0; entry < cmd_list.length; entry++) {
+                _appendItem(obj, {
+                    title: title_list[entry],
+                    cmd: cmd_list[entry].split(' ')
+                });
+            }
 
-        if (this.sourceActor != Main.layoutManager.dummyCursor) {
-            _appendItem(this, {
-                title: 'Power options',
-                cmd: ['gnome-control-center', 'power']
-            });
-
-            _appendItem(this, {
-                title: 'Event logs',
-                cmd: ['gnome-logs']
-            });
-
-            _appendItem(this, {
-                title: 'System',
-                cmd: ['gnome-control-center', 'info-overview']
-            });
-
-            _appendItem(this, {
-                title: 'Device Management',
-                cmd: ['gnome-control-center', 'display']
-            });
-
-            _appendItem(this, {
-                title: 'Disk Management',
-                cmd: ['gnome-disks']
-            });
-
-            this._appendSeparator();
+            obj._appendSeparator();
         }
 
-        _appendItem(this, {
-            title: 'Terminal',
-            cmd: ['gnome-terminal']
-        });
-
-        _appendItem(this, {
-            title: 'System monitor',
-            cmd: ['gnome-system-monitor']
-        });
-
-        _appendItem(this, {
-            title: 'Files',
-            cmd: ['nautilus']
-        });
-
-        _appendItem(this, {
-            title: 'Extensions',
-            cmd: ['gnome-shell-extension-prefs']
-        });
-
-        _appendItem(this, {
-            title: 'Settings',
-            cmd: ['gnome-control-center', 'wifi']
-        });
-
-        this._appendSeparator();
+        if (this.sourceActor != Main.layoutManager.dummyCursor) {
+            _appendList(
+                this,
+                Me.settings.get_strv('show-apps-button-context-menu-commands'),
+                Me.settings.get_strv('show-apps-button-context-menu-titles')
+            )
+        }
+        _appendList(
+            this,
+            Me.settings.get_strv('panel-context-menu-commands'),
+            Me.settings.get_strv('panel-context-menu-titles')
+        )
 
         let lockTaskbarMenuItem = this._appendMenuItem(Me.settings.get_boolean('taskbar-locked') ? _('Unlock taskbar') : _('Lock taskbar'));
         lockTaskbarMenuItem.connect('activate', () => {

--- a/appIcons.js
+++ b/appIcons.js
@@ -1755,33 +1755,86 @@ var MyShowAppsIconMenu = Utils.defineClass({
             return null;
         }
         
-        function _appendList(obj, cmd_list, title_list) {
-            if (cmd_list.length != title_list.length) {
+        function _appendList(obj, commandList, titleList) {
+            if (commandList.length != titleList.length) {
                 return;
             }
             
-            for (var entry = 0; entry < cmd_list.length; entry++) {
+            for (var entry = 0; entry < commandList.length; entry++) {
                 _appendItem(obj, {
-                    title: title_list[entry],
-                    cmd: cmd_list[entry].split(' ')
+                    title: titleList[entry],
+                    cmd: commandList[entry].split(' ')
                 });
             }
-
-            obj._appendSeparator();
         }
 
         if (this.sourceActor != Main.layoutManager.dummyCursor) {
+            _appendItem(this, {
+                title: 'Power options',
+                cmd: ['gnome-control-center', 'power']
+            });
+
+            _appendItem(this, {
+                title: 'Event logs',
+                cmd: ['gnome-logs']
+            });
+
+            _appendItem(this, {
+                title: 'System',
+                cmd: ['gnome-control-center', 'info-overview']
+            });
+
+            _appendItem(this, {
+                title: 'Device Management',
+                cmd: ['gnome-control-center', 'display']
+            });
+
+            _appendItem(this, {
+                title: 'Disk Management',
+                cmd: ['gnome-disks']
+            });
+
             _appendList(
                 this,
                 Me.settings.get_strv('show-apps-button-context-menu-commands'),
                 Me.settings.get_strv('show-apps-button-context-menu-titles')
             )
+
+            this._appendSeparator();
         }
+
+        _appendItem(this, {
+            title: 'Terminal',
+            cmd: ['gnome-terminal']
+        });
+
+        _appendItem(this, {
+            title: 'System monitor',
+            cmd: ['gnome-system-monitor']
+        });
+
+        _appendItem(this, {
+            title: 'Files',
+            cmd: ['nautilus']
+        });
+
+        _appendItem(this, {
+            title: 'Extensions',
+            cmd: ['gnome-shell-extension-prefs']
+        });
+
+        _appendItem(this, {
+            title: 'Settings',
+            cmd: ['gnome-control-center', 'wifi']
+        });
+
         _appendList(
             this,
             Me.settings.get_strv('panel-context-menu-commands'),
             Me.settings.get_strv('panel-context-menu-titles')
         )
+
+        this._appendSeparator();
 
         let lockTaskbarMenuItem = this._appendMenuItem(Me.settings.get_boolean('taskbar-locked') ? _('Unlock taskbar') : _('Lock taskbar'));
         lockTaskbarMenuItem.connect('activate', () => {

--- a/appIcons.js
+++ b/appIcons.js
@@ -1741,6 +1741,7 @@ var MyShowAppsIconMenu = Utils.defineClass({
     _dtpRedisplay: function() {
         this.removeAll();
 
+        // true if `which` can find the app
         function _checkExists(app) {
             let cmd = "which '" + app + "'";
             let out = GLib.spawn_command_line_sync(cmd);
@@ -1749,6 +1750,7 @@ var MyShowAppsIconMenu = Utils.defineClass({
             return out[3] == 0;
         }
 
+        // Only add menu entries for commands that exist in path
         function _appendItem(obj, info) {
             if (_checkExists(info.cmd[0])) {
                 let item = obj._appendMenuItem(_(info.title));
@@ -1756,11 +1758,7 @@ var MyShowAppsIconMenu = Utils.defineClass({
                 item.connect('activate', function() {
                     Util.spawn(info.cmd);
                 });
-
-                log("    FOUND: " + info.cmd[0]);
                 return item;
-            } else {
-                log("NOT FOUND: " + info.cmd[0]);
             }
 
             return null;

--- a/appIcons.js
+++ b/appIcons.js
@@ -1743,7 +1743,7 @@ var MyShowAppsIconMenu = Utils.defineClass({
         
         // Only add menu entries for commands that exist in path
         function _appendItem(obj, info) {
-            if (Utils.checkExists(info.cmd[0])) {
+            if (Utils.checkIfCommandExists(info.cmd[0])) {
                 let item = obj._appendMenuItem(_(info.title));
 
                 item.connect('activate', function() {

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -373,40 +373,24 @@
       <description>Animate Show Applications from the desktop</description>
     </key>
     <key type="as" name="show-apps-button-context-menu-commands">
-     <default>['gnome-control-center power',
-         'gnome-logs',
-         'gnome-control-center info-overview',
-         'gnome-control-center display',
-         'gnome-disks']</default>
-     <summary>Commands to run on Show Apps Menu</summary>
-     <description>Commands to run in the Show Apps button context menu</description>
+     <default>[]</default>
+     <summary>Show Apps button context menu commands</summary>
+     <description>Commands to add to the Show Apps button right click menu</description>
     </key>
     <key type="as" name="show-apps-button-context-menu-titles">
-     <default>['Power options',
-         'Event logs',
-         'System',
-         'Device Management',
-         'Disk Management']</default>
-     <summary>Titles to show on Show Apps Menu</summary>
-     <description>Titles to show in the Show Apps button context menu</description>
+     <default>[]</default>
+     <summary>Show Apps button context menu titles</summary>
+     <description>Titles for commands added to Show Apps button right click menu</description>
     </key>
     <key type="as" name="panel-context-menu-commands">
-     <default>['gnome-terminal',
-         'gnome-system-monitor',
-         'nautilus',
-         'gnome-shell-extension-prefs',
-         'gnome-control-center wifi']</default>
-     <summary>Commands to run on panel context menu</summary>
-     <description>Commands to run in the panel context menu</description>
+     <default>[]</default>
+     <summary>Panel context menu commands</summary>
+     <description>Commands to add to the panel right click menu</description>
     </key>
     <key type="as" name="panel-context-menu-titles">
-     <default>['Terminal',
-         'System monitor',
-         'Files',
-         'Extensions',
-         'Settings']</default>
-     <summary>Titles to show on panel context menu</summary>
-     <description>Titles to show in the panel context menu</description>
+     <default>[]</default>
+     <summary>Panel context menu titles</summary>
+     <description>Titles for commands added to panel right click menu</description>
     </key>
     <key type="b" name="show-activities-button">
       <default>false</default>

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -372,6 +372,42 @@
       <summary>Animate Show Applications from the desktop</summary>
       <description>Animate Show Applications from the desktop</description>
     </key>
+    <key type="as" name="show-apps-button-context-menu-commands">
+     <default>['gnome-control-center power',
+         'gnome-logs',
+         'gnome-control-center info-overview',
+         'gnome-control-center display',
+         'gnome-disks']</default>
+     <summary>Commands to run on Show Apps Menu</summary>
+     <description>Commands to run in the Show Apps button context menu</description>
+    </key>
+    <key type="as" name="show-apps-button-context-menu-titles">
+     <default>['Power options',
+         'Event logs',
+         'System',
+         'Device Management',
+         'Disk Management']</default>
+     <summary>Titles to show on Show Apps Menu</summary>
+     <description>Titles to show in the Show Apps button context menu</description>
+    </key>
+    <key type="as" name="panel-context-menu-commands">
+     <default>['gnome-terminal',
+         'gnome-system-monitor',
+         'nautilus',
+         'gnome-shell-extension-prefs',
+         'gnome-control-center wifi']</default>
+     <summary>Commands to run on panel context menu</summary>
+     <description>Commands to run in the panel context menu</description>
+    </key>
+    <key type="as" name="panel-context-menu-titles">
+     <default>['Terminal',
+         'System monitor',
+         'Files',
+         'Extensions',
+         'Settings']</default>
+     <summary>Titles to show on panel context menu</summary>
+     <description>Titles to show in the panel context menu</description>
+    </key>
     <key type="b" name="show-activities-button">
       <default>false</default>
       <summary>Show activities button</summary>
@@ -1186,7 +1222,7 @@
       <summary>Show progress bar on app icon</summary>
       <description>Whether to show progress bar overlay on app icon, for supported applications.</description>
     </key>
-     <key type="b" name="progress-show-count">
+    <key type="b" name="progress-show-count">
       <default>true</default>
       <summary>Show badge count on app icon</summary>
       <description>Whether to show badge count overlay on app icon, for supported applications.</description>

--- a/utils.js
+++ b/utils.js
@@ -882,8 +882,8 @@ var drawRoundedLine = function(cr, x, y, width, height, isRoundLeft, isRoundRigh
  * Check if an app exists in the system.
  * Depends on "which" to find app in $PATH
  */
-function checkExists(app) {
-    let cmd = "which '" + app + "'";
+function checkIfCommandExists(app) {
+    let cmd = "bash -c 'command -v " + app + "'";
     let out = GLib.spawn_command_line_sync(cmd);
 
     // out contains 1: stdout, 2: stderr, 3: exit code

--- a/utils.js
+++ b/utils.js
@@ -891,10 +891,14 @@ function checkIfCommandExists(app) {
         // Quotes around app value are important. They let command operate
         // on the whole value, instead of having shell interpret it.
         let cmd = "sh -c 'command -v \"" + app + "\"'";
-        let out = GLib.spawn_command_line_sync(cmd);
+        try {
+            let out = GLib.spawn_command_line_sync(cmd);
+            // out contains 1: stdout, 2: stderr, 3: exit code
+            answer = out[3] == 0;
+        } catch {
+            answer = false;
+        }
 
-        // out contains 1: stdout, 2: stderr, 3: exit code
-        answer = out[3] == 0;
         checkedCommandsMap.set(app, answer);
     }
     return answer;

--- a/utils.js
+++ b/utils.js
@@ -882,10 +882,20 @@ var drawRoundedLine = function(cr, x, y, width, height, isRoundLeft, isRoundRigh
  * Check if an app exists in the system.
  * Depends on "which" to find app in $PATH
  */
-function checkIfCommandExists(app) {
-    let cmd = "bash -c 'command -v " + app + "'";
-    let out = GLib.spawn_command_line_sync(cmd);
+var checkedCommandsMap = new Map();
 
-    // out contains 1: stdout, 2: stderr, 3: exit code
-    return out[3] == 0;
+function checkIfCommandExists(app) {
+    let answer = checkedCommandsMap.get(app);
+    if (answer === undefined) {
+        // Command is a shell built in, use shell to call it.
+        // Quotes around app value are important. They let command operate
+        // on the whole value, instead of having shell interpret it.
+        let cmd = "sh -c 'command -v \"" + app + "\"'";
+        let out = GLib.spawn_command_line_sync(cmd);
+
+        // out contains 1: stdout, 2: stderr, 3: exit code
+        answer = out[3] == 0;
+        checkedCommandsMap.set(app, answer);
+    }
+    return answer;
 }

--- a/utils.js
+++ b/utils.js
@@ -880,7 +880,6 @@ var drawRoundedLine = function(cr, x, y, width, height, isRoundLeft, isRoundRigh
 
 /**
  * Check if an app exists in the system.
- * Depends on "which" to find app in $PATH
  */
 var checkedCommandsMap = new Map();
 

--- a/utils.js
+++ b/utils.js
@@ -26,6 +26,7 @@ const Config = imports.misc.config;
 const GdkPixbuf = imports.gi.GdkPixbuf
 const Gi = imports._gi;
 const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Meta = imports.gi.Meta;
@@ -875,4 +876,16 @@ var drawRoundedLine = function(cr, x, y, width, height, isRoundLeft, isRoundRigh
     if (stroke != null)
         cr.setSource(stroke);
     cr.stroke();
+}
+
+/**
+ * Check if an app exists in the system.
+ * Depends on "which" to find app in $PATH
+ */
+function checkExists(app) {
+    let cmd = "which '" + app + "'";
+    let out = GLib.spawn_command_line_sync(cmd);
+
+    // out contains 1: stdout, 2: stderr, 3: exit code
+    return out[3] == 0;
 }


### PR DESCRIPTION
Proposing a partial fix to #847 by calling which on each command before adding it.

I ran into #847 on a vagrant ubuntu box I use as a dev environment (ubuntu server + ubuntu-gnome-desktop) which does not install a few of the options.

This change does not solve customizing the menu entries, but at least no invalid options are added.