### PR TITLE
Improve scroll source detection

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -222,10 +222,6 @@ var dtpPanel = Utils.defineClass({
             this.container = this._leftBox;
         }
 
-        if (this.statusArea.aggregateMenu) {
-            Utils.getIndicators(this.statusArea.aggregateMenu._volume)._dtpIgnoreScroll = 1;
-        }
-
         this.geom = this.getGeometry();
         
         // The overview uses the panel height as a margin by way of a "ghost" transparent Clone
@@ -457,7 +453,6 @@ var dtpPanel = Utils.defineClass({
 
             this._displayShowDesktopButton(false);
 
-            delete Utils.getIndicators(this.statusArea.aggregateMenu._volume)._dtpIgnoreScroll;
             setMenuArrow(this.statusArea.aggregateMenu._indicators.get_last_child(), St.Side.TOP);
 
             if (DateMenu.IndicatorPad) {
@@ -1141,7 +1136,7 @@ var dtpPanel = Utils.defineClass({
         let scrollAction = Me.settings.get_string('scroll-panel-action');
         let direction = Utils.getMouseScrollDirection(event);
 
-        if (!this._checkIfIgnoredSrollSource(event.get_source()) && !this._timeoutsHandler.getId(T6)) {
+        if (!this._checkIfIgnoredScrollSource(event.get_source()) && !this._timeoutsHandler.getId(T6)) {
             if (direction && scrollAction === 'SWITCH_WORKSPACE') {
                 let args = [global.display];
 
@@ -1154,10 +1149,10 @@ var dtpPanel = Utils.defineClass({
                 
                 Utils.activateSiblingWindow(windows, direction);
             } else if (scrollAction === 'CHANGE_VOLUME' && !event.is_pointer_emulated()) {
-                var proto = Volume.Indicator.prototype;
-                var func = proto.vfunc_scroll_event || proto._onScrollEvent;
-    
-                func.call(Main.panel.statusArea.aggregateMenu._volume, 0, event);
+                let volumeIndicator = this.statusArea.aggregateMenu._volume;
+                var scrollFunc = volumeIndicator.vfunc_scroll_event || volumeIndicator._onScrollEvent;
+
+                scrollFunc.call(volumeIndicator, actor, event);
             } else {
                 return;
             }
@@ -1170,10 +1165,11 @@ var dtpPanel = Utils.defineClass({
         }
     },
 
-    _checkIfIgnoredSrollSource: function(source) {
+    _checkIfIgnoredScrollSource: function(source) {
         let ignoredConstr = ['WorkspaceIndicator'];
+        let isVolumeIndicator = (source === this.statusArea.aggregateMenu._volume);
 
-        return source._dtpIgnoreScroll || ignoredConstr.indexOf(source.constructor.name) >= 0;
+        return isVolumeIndicator || ignoredConstr.indexOf(source.constructor.name) >= 0;
     },
 
     _initProgressManager: function() {


### PR DESCRIPTION
I just got an issue submitted at aleho/gnome-shell-volume-mixer#119.

It is actually caused by a race condition: If Volume Mixer is loaded before Dash-to-panel scrolling is ignored (by setting a custom property on the indicator instance), if afterwards, scrolling will be triggered in Dash-to-panel as well (because Volume Mixer replaces the aggregate menu indicator).

There are three possible solutions to this that came to my mind:

1. Implement your custom property (see [here](https://github.com/home-sweet-gnome/dash-to-panel/blob/616ba8622fa9e6cf5042cbf1ae29a266d49104f5/panel.js#L226) and [here](https://github.com/home-sweet-gnome/dash-to-panel/blob/616ba8622fa9e6cf5042cbf1ae29a266d49104f5/panel.js#L1176)),
2. stop propagating the scroll event in Volume Mixer, or
3. have Dash-to-panel implement a better check for scrolling.

Solution 1 is bad, because now your extension has an undocumented API user. I see icebergs ahead. Solution 2 is equally bad, because then I'm deviating from the original behavior in GNOME.

Solution 3 makes the most sense in my opinion, because your current implementation potentially breaks other extensions as well. I think checking for implementations of `vfunc_scroll_event()` on a scroll source means there's a direct consumer for this event and it might be a safe bet to say "they wanted a scroll event, we shouldn't interfere".

Sadly, accessing 'vfunc_scroll_event' is broken on (at least) Clutter objects, completely killing execution of code afterwards (without any errors being logged at all), try entering e.g. ` Main.panel.statusArea.aggregateMenu.vfunc_scroll_event` in lg.

So, my current proposal for the volume indicator: Just check if the event source is the actual indicator instance.

I checked this PR with the vanilla indicator and also with Volume Mixer. Both seem to work fine.