### PR TITLE
Use transparent backgrounds for show-apps-icon

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1622,11 +1622,16 @@ var ShowAppsIconWrapper = Utils.defineClass({
 
         let customIconPath = Me.settings.get_string('show-apps-icon-file');
 
+        this.actor.set_style("background-color: transparent;");
+        this.realShowAppsIcon.icon.set_style("background-color: transparent;");
+
         this.realShowAppsIcon.icon.createIcon = function(size) {
             this._iconActor = new St.Icon({ icon_name: 'view' + (Config.PACKAGE_VERSION < '3.20' ? '' : '-app') + '-grid-symbolic',
                                             icon_size: size,
                                             style_class: 'show-apps-icon',
                                             track_hover: true });
+
+            this._iconActor.set_style("background-color: transparent;");
 
             if (customIconPath) {
                 this._iconActor.gicon = new Gio.FileIcon({ file: Gio.File.new_for_path(customIconPath) });


### PR DESCRIPTION
How's this for a fix to #911? By forcing transparent on these three objects we override the backgrounds set by Arc (and the Deepin theme as well).

This behavior is consistent with what happens today when using a theme that doesn't define a background-color for these classes. The only other potential improvement I'd recommend is to carry over the taskbarAppIcon highlight behavior so this button is uniform with the rest of the panel buttons.