### PR TITLE
Override show-apps background for transparent icons

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1622,11 +1622,16 @@ var ShowAppsIconWrapper = Utils.defineClass({
 
         let customIconPath = Me.settings.get_string('show-apps-icon-file');
 
+        this.actor.set_style("background-color: transparent;");
+        this.realShowAppsIcon.icon.set_style("background-color: transparent;");
+
         this.realShowAppsIcon.icon.createIcon = function(size) {
             this._iconActor = new St.Icon({ icon_name: 'view' + (Config.PACKAGE_VERSION < '3.20' ? '' : '-app') + '-grid-symbolic',
                                             icon_size: size,
                                             style_class: 'show-apps-icon',
                                             track_hover: true });
+
+            this._iconActor.set_style("background-color: transparent;");
 
             if (customIconPath) {
                 this._iconActor.gicon = new Gio.FileIcon({ file: Gio.File.new_for_path(customIconPath) });

--- a/appIcons.js
+++ b/appIcons.js
@@ -1622,16 +1622,11 @@ var ShowAppsIconWrapper = Utils.defineClass({
 
         let customIconPath = Me.settings.get_string('show-apps-icon-file');
 
-        this.actor.set_style("background-color: transparent;");
-        this.realShowAppsIcon.icon.set_style("background-color: transparent;");
-
         this.realShowAppsIcon.icon.createIcon = function(size) {
             this._iconActor = new St.Icon({ icon_name: 'view' + (Config.PACKAGE_VERSION < '3.20' ? '' : '-app') + '-grid-symbolic',
                                             icon_size: size,
                                             style_class: 'show-apps-icon',
                                             track_hover: true });
-
-            this._iconActor.set_style("background-color: transparent;");
 
             if (customIconPath) {
                 this._iconActor.gicon = new Gio.FileIcon({ file: Gio.File.new_for_path(customIconPath) });

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -31,6 +31,7 @@
 	border: none;
 	margin: 0;
 	padding: 0;
+  background: none;
 }
 
 #dashtopanelScrollview .app-well-app .overview-label {


### PR DESCRIPTION
Here's a better fix for #911 that only touches stylesheet.css. Looks like we only need to set the background on the overview-icon. I checked this against the Deepin and Arc shell themes and verified the transparency.