### PR TITLE
Toggle workspace switch popup

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -3237,8 +3237,6 @@
         </child>
         <child>
           <object class="GtkListBoxRow" id="listboxrow_scroll_panel_options_show_ws_popup">
-            <property name="width_request">100</property>
-            <property name="height_request">80</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -3235,6 +3235,69 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="GtkListBoxRow" id="listboxrow_scroll_panel_options_show_ws_popup">
+            <property name="width_request">100</property>
+            <property name="height_request">80</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <child>
+              <object class="GtkGrid" id="grid_scroll_panel_options_show_ws_popup">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="margin_right">12</property>
+                <property name="margin_top">12</property>
+                <property name="margin_bottom">12</property>
+                <property name="column_spacing">32</property>
+                <child>
+                  <object class="GtkLabel" id="scroll_panel_options_show_ws_popup_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Show popup when changing workspace</property>
+                    <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="scroll_panel_options_show_ws_popup_description">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">This affects workspace popup when scrolling on the panel only.</property>
+                    <property name="wrap">True</property>
+                    <property name="xalign">0</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="scroll_panel_options_show_ws_popup_switch">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                    <property name="height">2</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/panel.js
+++ b/panel.js
@@ -1249,11 +1249,10 @@ var dtpPanel = Utils.defineClass({
                 //gnome-shell < 3.30 needs an additional "screen" param
                 global.screen ? args.push(global.screen) : 0;
 
-                if (!Me.settings.get_boolean('scroll-panel-show-ws-popup'))
-                    Main.wm._workspaceSwitcherPopup = { display: () => {} };
+                let showWsPopup = Me.settings.get_boolean('scroll-panel-show-ws-popup');
+                showWsPopup ? 0 : Main.wm._workspaceSwitcherPopup = { display: () => {} };
                 Main.wm._showWorkspaceSwitcher.apply(Main.wm, args.concat([0, { get_name: () => 'switch---' + direction }]));
-                if (!Me.settings.get_boolean('scroll-panel-show-ws-popup'))
-                    Main.wm._workspaceSwitcherPopup = null;
+                showWsPopup ? 0 : Main.wm._workspaceSwitcherPopup = null;
             } else if (direction && scrollAction === 'CYCLE_WINDOWS') {
                 let windows = this.taskbar.getAppInfos().reduce((ws, appInfo) => ws.concat(appInfo.windows), []);
                 

--- a/panel.js
+++ b/panel.js
@@ -1249,7 +1249,11 @@ var dtpPanel = Utils.defineClass({
                 //gnome-shell < 3.30 needs an additional "screen" param
                 global.screen ? args.push(global.screen) : 0;
 
+                if (!Me.settings.get_boolean('scroll-panel-show-ws-popup'))
+                    Main.wm._workspaceSwitcherPopup = { display: () => {} };
                 Main.wm._showWorkspaceSwitcher.apply(Main.wm, args.concat([0, { get_name: () => 'switch---' + direction }]));
+                if (!Me.settings.get_boolean('scroll-panel-show-ws-popup'))
+                    Main.wm._workspaceSwitcherPopup = null;
             } else if (direction && scrollAction === 'CYCLE_WINDOWS') {
                 let windows = this.taskbar.getAppInfos().reduce((ws, appInfo) => ws.concat(appInfo.windows), []);
                 

--- a/prefs.js
+++ b/prefs.js
@@ -1482,11 +1482,18 @@ const Settings = new Lang.Class({
                 this._settings.set_int('scroll-panel-delay', widget.get_value());
             }));
 
+            this._settings.bind('scroll-panel-show-ws-popup',
+                            this._builder.get_object('scroll_panel_options_show_ws_popup_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+
             dialog.connect('response', Lang.bind(this, function(dialog, id) {
                 if (id == 1) {
                     // restore default settings
                     this._settings.set_value('scroll-panel-delay', this._settings.get_default_value('scroll-panel-delay'));
                     this._builder.get_object('scroll_panel_options_delay_spinbutton').set_value(this._settings.get_int('scroll-panel-delay'));
+
+                    this._settings.set_value('scroll-panel-show-ws-popup', this._settings.get_default_value('scroll-panel-show-ws-popup'));
                 } else {
                     // remove the settings box so it doesn't get destroyed;
                     dialog.get_content_area().remove(box);

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -660,6 +660,10 @@
       <summary>Delay between panel mouse scroll events</summary>
       <description>Set the minimum delay between panel mouse scroll events</description>
     </key>
+    <key type="b" name="scroll-panel-show-ws-popup">
+      <default>true</default>
+      <summary>Show the workspace switch head-up when workspace is changed by scrolling on the panel</summary>
+    </key>
     <key name="scroll-icon-action" enum="org.gnome.shell.extensions.dash-to-panel.scrollAction">
       <default>'CYCLE_WINDOWS'</default>
       <summary>Action when scrolling over a running app</summary>


### PR DESCRIPTION
This PR adds a toggle to show/hide the workspace switch popup when scrolling on the panel to change workspace.