### PR TITLE
fix es6 grammar warning

### DIFF
--- a/intellihide.js
+++ b/intellihide.js
@@ -21,7 +21,7 @@ const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 
-const GrabHelper = imports.ui.grabHelper;
+var GrabHelper = imports.ui.grabHelper;
 const Layout = imports.ui.layout;
 const Main = imports.ui.main;
 const OverviewControls = imports.ui.overviewControls;


### PR DESCRIPTION
 gnome-shell warning: Some code accessed the property '_grabHelperStack' on the module 'grabHelper'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.