### PR TITLE
add option to change the preview window icon size

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -2096,6 +2096,12 @@
     <property name="step_increment">1</property>
     <property name="page_increment">100</property>
   </object>
+  <object class="GtkAdjustment" id="preview_custom_icon_size_adjustment">
+    <property name="lower">8</property>
+    <property name="upper">48</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">100</property>
+  </object>
   <object class="GtkScrolledWindow" id="box_window_preview_options">
     <property name="visible">True</property>
     <property name="can_focus">True</property>
@@ -2748,6 +2754,92 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkGrid" id="grid_preview_custom_icon_size">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">12</property>
+                        <property name="column_spacing">32</property>
+                        <child>
+                            <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="spacing">8</property>
+                                <child>
+                                  <object class="GtkSwitch" id="preview_custom_icon_size_switch">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinButton" id="preview_custom_icon_size_spinbutton">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="halign">end</property>
+                                    <property name="width_chars">4</property>
+                                    <property name="text">6</property>
+                                    <property name="adjustment">preview_custom_icon_size_adjustment</property>
+                                    <property name="numeric">True</property>
+                                    <property name="value">6</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">0</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                            </object>
+                            <packing>
+                                <property name="left_attach">1</property>
+                            </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="preview_custom_icon_size_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Icon size (px) of the window preview</property>
+                            <property name="use_markup">True</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="preview_custom_icon_size_description">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">If disabled, the previews icon size will be based on headerbar size</property>
+                            <property name="wrap">True</property>
+                            <property name="max_width_chars">40</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkGrid" id="grid_preview_title_size">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -2786,7 +2878,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
+                        <property name="top_attach">2</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -2831,7 +2923,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
+                        <property name="top_attach">3</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -2870,7 +2962,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
+                        <property name="top_attach">4</property>
                         <property name="width">2</property>
                       </packing>
                     </child>

--- a/prefs.js
+++ b/prefs.js
@@ -1179,6 +1179,14 @@ const Settings = new Lang.Class({
                             this._builder.get_object('preview_custom_opacity_spinbutton'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
+            this._settings.bind('window-preview-use-custom-icon-size',
+                            this._builder.get_object('preview_custom_icon_size_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+            this._settings.bind('window-preview-use-custom-icon-size',
+                            this._builder.get_object('preview_custom_icon_size_spinbutton'),
+                            'sensitive',
+                            Gio.SettingsBindFlags.DEFAULT);
 
             this._builder.get_object('preview_custom_opacity_spinbutton').set_value(this._settings.get_int('preview-custom-opacity'));
             this._builder.get_object('preview_custom_opacity_spinbutton').connect('value-changed', Lang.bind (this, function(widget) {
@@ -1264,6 +1272,11 @@ const Settings = new Lang.Class({
             this._builder.get_object('preview_title_size_spinbutton').connect('value-changed', Lang.bind (this, function(widget) {
                 this._settings.set_int('window-preview-title-font-size', widget.get_value());
             }));
+            
+            this._builder.get_object('preview_custom_icon_size_spinbutton').set_value(this._settings.get_int('window-preview-custom-icon-size'));
+            this._builder.get_object('preview_custom_icon_size_spinbutton').connect('value-changed', Lang.bind (this, function(widget) {
+                this._settings.set_int('window-preview-custom-icon-size', widget.get_value());
+            }));
 
             this._builder.get_object('grid_preview_title_weight_combo').set_active_id(this._settings.get_string('window-preview-title-font-weight'));
             this._builder.get_object('grid_preview_title_weight_combo').connect('changed', Lang.bind (this, function(widget) {
@@ -1291,6 +1304,8 @@ const Settings = new Lang.Class({
                     this._builder.get_object('animation_time_spinbutton').set_value(this._settings.get_int('window-preview-animation-time'));
 
                     this._settings.set_value('preview-use-custom-opacity', this._settings.get_default_value('preview-use-custom-opacity'));
+                    
+                    this._settings.set_value('window-preview-use-custom-icon-size', this._settings.get_default_value('window-preview-use-custom-icon-size'));
 
                     this._settings.set_value('preview-custom-opacity', this._settings.get_default_value('preview-custom-opacity'));
                     this._builder.get_object('preview_custom_opacity_spinbutton').set_value(this._settings.get_int('preview-custom-opacity'));
@@ -1324,6 +1339,9 @@ const Settings = new Lang.Class({
 
                     this._settings.set_value('window-preview-title-font-size', this._settings.get_default_value('window-preview-title-font-size'));
                     this._builder.get_object('preview_title_size_spinbutton').set_value(this._settings.get_int('window-preview-title-font-size'));
+                    
+                    this._settings.set_value('window-preview-custom-icon-size', this._settings.get_default_value('window-preview-custom-icon-size'));
+                    this._builder.get_object('preview_custom_icon_size_spinbutton').set_value(this._settings.get_int('window-preview-custom-icon-size'));
 
                     this._settings.set_value('window-preview-title-font-weight', this._settings.get_default_value('window-preview-title-font-weight'));
                     this._builder.get_object('grid_preview_title_weight_combo').set_active_id(this._settings.get_string('window-preview-title-font-weight'));

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -482,6 +482,16 @@
       <summary>Window previews title font size</summary>
       <description>This defines the window preview titles font size.</description>
     </key>
+    <key type="b" name="window-preview-use-custom-icon-size">
+      <default>false</default>
+      <summary>Window previews use custom icon size</summary>
+      <description>Window previews use custom application icon size.</description>
+    </key>
+    <key type="i" name="window-preview-custom-icon-size">
+      <default>16</default>
+      <summary>Window previews custom icon size</summary>
+      <description>Window previews custom application icon size.</description>
+    </key>
     <key type="i" name="window-preview-animation-time">
       <default>260</default>
       <summary>Window previews animation time</summary>

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -822,7 +822,12 @@ var Preview = Utils.defineClass({
         this._removeWindowSignals();
         this.window = window;
         this._needsCloseButton = window.can_close() && !Utils.checkIfWindowHasTransient(window);
-        this._updateHeader();
+        
+        if (Me.settings.get_boolean('window-preview-use-custom-icon-size')){
+            this._updateHeader(Me.settings.get_int('window-preview-custom-icon-size'));
+        } else {
+            this._updateHeader(headerHeight / scaleFactor * .6);
+        }
     },
 
     animateOut: function() {
@@ -946,9 +951,8 @@ var Preview = Utils.defineClass({
         }
     },
 
-    _updateHeader: function() {
+    _updateHeader: function(iconTextureSize) {
         if (headerHeight) {
-            let iconTextureSize = headerHeight / scaleFactor * .6;
             let icon = this._previewMenu.getCurrentAppIcon().app.create_icon_texture(iconTextureSize);
             let workspaceIndex = '';
             let workspaceStyle = null;


### PR DESCRIPTION
These changes add the option to change the preview window icon size:

16px:
![image](https://user-images.githubusercontent.com/11244067/88459856-a0ef8e80-ce6e-11ea-9044-cad430335027.png)
![image](https://user-images.githubusercontent.com/11244067/88459868-a77e0600-ce6e-11ea-93c7-3ab68a45478f.png)

disabled:
![image](https://user-images.githubusercontent.com/11244067/88459930-093e7000-ce6f-11ea-9739-95c055064e2c.png)
![image](https://user-images.githubusercontent.com/11244067/88459934-1196ab00-ce6f-11ea-8ea1-ca2d02823f1f.png)
