### PR TITLE
Running indicator Metro improvements

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1049,18 +1049,24 @@ var taskbarAppIcon = Utils.defineClass({
         }
 
         if (type == DOT_STYLE.SOLID || type == DOT_STYLE.METRO) {
+            let hoverSpacing = 4;
+            let fullSize = (isFocused || this.actor.hover || type != DOT_STYLE.METRO) ? true : false;
+            startX = fullSize ? startX : startX + hoverSpacing;
+            areaSizeNew = fullSize ? areaSize : areaSize - (hoverSpacing * 2);
+
             if (type == DOT_STYLE.SOLID || n <= 1) {
                 cr.translate(startX, startY);
                 Clutter.cairo_set_source_color(cr, bodyColor);
                 cr.newSubPath();
-                cr.rectangle.apply(cr, [0, 0].concat(isHorizontalDots ? [areaSize, size] : [size, areaSize]));
+                cr.rectangle.apply(cr, [0, 0].concat(isHorizontalDots ? [areaSizeNew, size] : [size, areaSizeNew]));
                 cr.fill();
+
             } else {
                 let blackenedLength = (1 / 48) * areaSize; // need to scale with the SVG for the stacked highlight
-                let darkenedLength = isFocused ? (2 / 48) * areaSize : (10 / 48) * areaSize;
+                let darkenedLength = (isFocused || (this.actor.hover && type == DOT_STYLE.METRO)) ? (3 / 48) * areaSize : (8 / 48) * areaSize;
                 let blackenedColor = bodyColor.shade(.3);
                 let darkenedColor = bodyColor.shade(.7);
-                let solidDarkLength = areaSize - darkenedLength;
+                let solidDarkLength = areaSizeNew - darkenedLength;
                 let solidLength = solidDarkLength - blackenedLength;
 
                 cr.translate(startX, startY);

--- a/img/highlight_stacked_bg.svg
+++ b/img/highlight_stacked_bg.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 1">
 	<g fill="#000000">
-		<rect x="45" width="1" height="1" opacity="0.5"/>
-		<rect x="46" width="2"  height="1" opacity="0.2"/>
+		<rect x="44" width="1" height="1" opacity="0.5"/>
+		<rect x="45" width="3"  height="1" opacity="0.2"/>
 	</g>
 </svg>


### PR DESCRIPTION
Based on Windows's Metro panel I'm sending some changes to keep the metro style closer to the windows panel.

- When the button is not in focus nor hover by cursor it will display the a bit smaller (4px on left and 4px on right):
![image](https://user-images.githubusercontent.com/11244067/88593551-1a85a900-d036-11ea-94ed-654c21e445f7.png)
- The size of the indicator (grouped application) was modified to match perfectly the original sizes of metro:
![image](https://user-images.githubusercontent.com/11244067/88593920-a8fa2a80-d036-11ea-8e6d-5e1ad60f345a.png)

I have compared with the actual metro to make sure the size match perfectly.

If you prefer to not merge it and keep the way it is, can I add options (settings) to achieve this results?