### PR TITLE
add an option to select which sides of margin the app icon button should have

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -4964,6 +4964,38 @@
                             <property name="top_attach">0</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkLabel" id="appicon_margin_side_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Margin Side</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="appicon_margin_side_combo">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <items>
+                              <item id="BOTH" translatable="yes">Both Sides</item>
+                              <item id="RIGHT" translatable="yes">Horizontal: Right / Vertical: Top</item>
+                              <item id="LEFT" translatable="yes">Horizontal: Left / Vertical: Bottom</item>
+                            </items>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/appIcons.js
+++ b/appIcons.js
@@ -575,8 +575,26 @@ var taskbarAppIcon = Utils.defineClass({
     _setAppIconPadding: function() {
         let padding = getIconPadding();
         let margin = Me.settings.get_int('appicon-margin');
+
+        let isVertical = this.dtpPanel.checkIfVertical();
+        let margins ={};
+
+        switch(Me.settings.get_string('app-margin-side')){
+            case 'BOTH':
+                margins = {'v': margin + "px 0 " + margin + "px 0",
+                           'h': "0 " + margin + "px 0 " + margin + "px"};
+                break;
+            case 'RIGHT':
+                margins = {'v': margin + "px 0 0 0",
+                           'h': "0 " + margin + "px 0 0"};
+                break;
+            case 'LEFT':
+                margins = {'v': "0 0 " + margin + "px 0",
+                           'h': "0 0 0 " + margin + "px"}
+                break;
+        }
         
-        this.actor.set_style('padding:' + (this.dtpPanel.checkIfVertical() ? margin + 'px 0' : '0 ' + margin + 'px;'));
+        this.actor.set_style('padding:' + margins[isVertical ? 'v' : 'h']);
         this._iconContainer.set_style('padding: ' + padding + 'px;');
     },
 

--- a/panel.js
+++ b/panel.js
@@ -652,6 +652,7 @@ var dtpPanel = Utils.defineClass({
                 Me.settings,
                 [
                     'changed::appicon-margin',
+                    'changed::app-margin-side',
                     'changed::appicon-padding'
                 ],
                 () => this.taskbar.resetAppIcons()

--- a/prefs.js
+++ b/prefs.js
@@ -494,6 +494,11 @@ const Settings = new Lang.Class({
             panel_size_scale.set_inverted(true);
         }
 
+        this._builder.get_object('appicon_margin_side_combo').set_active_id(this._settings.get_string('app-margin-side'));
+        this._builder.get_object('appicon_margin_side_combo').connect('changed', Lang.bind (this, function(widget) {
+            this._settings.set_string('app-margin-side', widget.get_active_id());
+        }));
+
         // Dots Position option
         let dotPosition = this._settings.get_string('dot-position');
 

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="gnome-shell-extensions">
+  <enum id='org.gnome.shell.extensions.dash-to-panel.appSide'>
+    <value value='0' nick='BOTH'/>
+    <value value='1' nick='RIGHT'/>
+    <value value='2' nick='LEFT'/>
+  </enum>
   <enum id='org.gnome.shell.extensions.dash-to-panel.dotStyle'>
     <value value='0' nick='DOTS'/>
     <value value='1' nick='SQUARES'/>
@@ -703,6 +708,11 @@
         <default>8</default>
         <summary>App icon margin</summary>
         <description>Set the margin for application icons in the embedded dash.</description>
+    </key>
+    <key name="app-margin-side" enum="org.gnome.shell.extensions.dash-to-panel.appSide">
+      <default>'BOTH'</default>
+      <summary>App icon margin side</summary>
+      <description>set if margin of app icon will be placed on both sides or just one</description>
     </key>
     <key type="i" name="appicon-padding">
         <default>4</default>


### PR DESCRIPTION
These changes make possible to have an odd number of pixels between each app icon.

The actual implementation uses margin in left and also right(or top and bottom for vertical), so 1px become 2px (1+1).

With that changes I can use the same as windows 10 does: having only 1px between buttons:
![image](https://user-images.githubusercontent.com/11244067/88612732-3dc64d80-d062-11ea-8a76-6281d0444b7f.png)

![image](https://user-images.githubusercontent.com/11244067/88612847-7d8d3500-d062-11ea-912b-6e5db1cf8ef8.png)
