### PR TITLE
window preview icon size change

### DIFF
--- a/windowPreview.js
+++ b/windowPreview.js
@@ -948,7 +948,7 @@ var Preview = Utils.defineClass({
 
     _updateHeader: function() {
         if (headerHeight) {
-            let iconTextureSize = headerHeight / scaleFactor * .6;
+            let iconTextureSize = (Me.settings.get_int('window-preview-title-font-size') <= 16) ? 16 : 22;
             let icon = this._previewMenu.getCurrentAppIcon().app.create_icon_texture(iconTextureSize);
             let workspaceIndex = '';
             let workspaceStyle = null;

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -948,7 +948,7 @@ var Preview = Utils.defineClass({
 
     _updateHeader: function() {
         if (headerHeight) {
-            let iconTextureSize = (Me.settings.get_int('window-preview-title-font-size') <= 16) ? 16 : 22;
+            let iconTextureSize = (Me.settings.get_int('window-preview-title-font-size') <= 16) ? 16 : 24;
             let icon = this._previewMenu.getCurrentAppIcon().app.create_icon_texture(iconTextureSize);
             let workspaceIndex = '';
             let workspaceStyle = null;


### PR DESCRIPTION
window preview icon size will change based on font size
Discussion from #1099 

I think I found out a better way to do than the last pull request.

```javascript
let iconTextureSize = (Me.settings.get_int('window-preview-title-font-size') <= 16) ? 16 : 22;
```

just this line of change nothing else, basically it check the font size if less or equal to 16 then use 16 otherwise 22 (22 is the default now)

Since I saw the font size box is limited to maximum of 24px there is no need to over-complicate with other icon sizes, and also its attached to the font size, so there is no need to use scale factory or the height size on it.

I have tested (even with scale factory at 200%) and it seems working fine.