### PR TITLE
Display panel along percent of screen edge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UUID = dash-to-panel@jderose9.github.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = appIcons.js convenience.js panel.js panelManager.js proximity.js intellihide.js progress.js panelPositions.js panelStyle.js overview.js taskbar.js transparency.js windowPreview.js prefs.js update.js utils.js Settings.ui
+EXTRA_MODULES = appIcons.js convenience.js panel.js panelManager.js proximity.js intellihide.js progress.js panelPositions.js panelSettings.js panelStyle.js overview.js taskbar.js transparency.js windowPreview.js prefs.js update.js utils.js Settings.ui
 EXTRA_IMAGES = highlight_stacked_bg.svg highlight_stacked_bg_2.svg highlight_stacked_bg_3.svg
 
 TOLOCALIZE =  prefs.js appIcons.js update.js

--- a/Settings.ui
+++ b/Settings.ui
@@ -2765,44 +2765,45 @@
                         <property name="margin_top">12</property>
                         <property name="column_spacing">32</property>
                         <child>
-                            <object class="GtkBox">
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">8</property>
+                            <child>
+                              <object class="GtkSwitch" id="preview_custom_icon_size_switch">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="spacing">8</property>
-                                <child>
-                                  <object class="GtkSwitch" id="preview_custom_icon_size_switch">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="halign">end</property>
-                                    <property name="valign">center</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="preview_custom_icon_size_spinbutton">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="halign">end</property>
-                                    <property name="width_chars">4</property>
-                                    <property name="text">6</property>
-                                    <property name="adjustment">preview_custom_icon_size_adjustment</property>
-                                    <property name="numeric">True</property>
-                                    <property name="value">6</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">0</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                            </object>
-                            <packing>
-                                <property name="left_attach">1</property>
-                            </packing>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="preview_custom_icon_size_spinbutton">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="width_chars">4</property>
+                                <property name="text">6</property>
+                                <property name="adjustment">preview_custom_icon_size_adjustment</property>
+                                <property name="numeric">True</property>
+                                <property name="value">6</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="preview_custom_icon_size_label">
@@ -4147,9 +4148,8 @@
                     </child>
                   </object>
                   <packing>
-                     <property name="left_attach">1</property>
-                     <property name="top_attach">0</property>
-                     <property name="top_attach">1</property>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
                   </packing>
                 </child>
               </object>
@@ -4826,124 +4826,240 @@
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="margin_start">12</property>
+                        <property name="margin_top">4</property>
+                        <property name="margin_bottom">4</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
                         <property name="top_attach">1</property>
+                        <property name="width">2</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="panel_position_box">
+                      <object class="GtkFrame" id="panel_size_frame">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_top">18</property>
-                        <property name="margin_bottom">6</property>
-                        <property name="spacing">32</property>
+                        <property name="margin_top">6</property>
+                        <property name="label_xalign">0</property>
+                        <property name="shadow_type">none</property>
                         <child>
-                          <object class="GtkLabel" id="panel_position_label">
+                          <object class="GtkListBox" id="panel_size_listbox">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="hexpand">True</property>
-                            <property name="label" translatable="yes">Panel screen position</property>
-                            <property name="xalign">0</property>
+                            <property name="selection_mode">none</property>
+                            <child>
+                              <object class="GtkListBoxRow" id="panel_size_listboxrow">
+                                <property name="width_request">100</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <child>
+                                  <object class="GtkGrid" id="panel_size_grid">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_top">6</property>
+                                    <property name="margin_bottom">6</property>
+                                    <property name="row_spacing">12</property>
+                                    <property name="column_spacing">32</property>
+                                    <child>
+                                      <object class="GtkScale" id="panel_size_scale">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="valign">baseline</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="adjustment">panel_size_adjustment</property>
+                                        <property name="round_digits">0</property>
+                                        <property name="digits">0</property>
+                                        <property name="value_pos">right</property>
+                                        <signal name="format-value" handler="panel_size_scale_format_value_cb" swapped="no"/>
+                                        <signal name="value-changed" handler="panel_size_scale_value_changed_cb" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="panel_size_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Panel thickness
+(default is 48)</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="panel_length_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Panel length (%)
+(default is 100)</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkScale" id="panel_length_scale">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="valign">baseline</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="adjustment">panel_length_adjustment</property>
+                                        <property name="round_digits">0</property>
+                                        <property name="digits">0</property>
+                                        <property name="value_pos">right</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="panel_anchor_combo">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="valign">center</property>
+                                        <items>
+                                          <item id="START" translatable="yes">Start</item>
+                                          <item id="MIDDLE" translatable="yes">Middle</item>
+                                          <item id="END" translatable="yes">End</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="panel_anchor_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Anchor</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="panel_position_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="label" translatable="yes">Panel screen position</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="panel_position_butttons_box">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="spacing">32</property>
+                                        <child>
+                                          <object class="GtkRadioButton" id="position_bottom_button">
+                                            <property name="label" translatable="yes">Bottom</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="halign">center</property>
+                                            <property name="valign">center</property>
+                                            <property name="xalign">0</property>
+                                            <property name="active">True</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="clicked" handler="position_bottom_button_clicked_cb" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="position_top_button">
+                                            <property name="label" translatable="yes">Top</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="halign">center</property>
+                                            <property name="valign">center</property>
+                                            <property name="xalign">0</property>
+                                            <property name="image_position">bottom</property>
+                                            <property name="draw_indicator">True</property>
+                                            <property name="group">position_bottom_button</property>
+                                            <signal name="clicked" handler="position_top_button_clicked_cb" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="position_left_button">
+                                            <property name="label" translatable="yes">Left</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="halign">center</property>
+                                            <property name="valign">center</property>
+                                            <property name="xalign">0</property>
+                                            <property name="image_position">bottom</property>
+                                            <property name="draw_indicator">True</property>
+                                            <property name="group">position_bottom_button</property>
+                                            <signal name="clicked" handler="position_left_button_clicked_cb" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="position_right_button">
+                                            <property name="label" translatable="yes">Right</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="halign">center</property>
+                                            <property name="valign">center</property>
+                                            <property name="xalign">0</property>
+                                            <property name="image_position">bottom</property>
+                                            <property name="draw_indicator">True</property>
+                                            <property name="group">position_bottom_button</property>
+                                            <signal name="clicked" handler="position_right_button_clicked_cb" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
-                        <child>
-                          <object class="GtkBox" id="panel_position_butttons_box">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">32</property>
-                            <child>
-                              <object class="GtkRadioButton" id="position_bottom_button">
-                                <property name="label" translatable="yes">Bottom</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="xalign">0</property>
-                                <property name="active">True</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="clicked" handler="position_bottom_button_clicked_cb" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkRadioButton" id="position_top_button">
-                                <property name="label" translatable="yes">Top</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="xalign">0</property>
-                                <property name="image_position">bottom</property>
-                                <property name="draw_indicator">True</property>
-                                <property name="group">position_bottom_button</property>
-                                <signal name="clicked" handler="position_top_button_clicked_cb" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkRadioButton" id="position_left_button">
-                                <property name="label" translatable="yes">Left</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="xalign">0</property>
-                                <property name="image_position">bottom</property>
-                                <property name="draw_indicator">True</property>
-                                <property name="group">position_bottom_button</property>
-                                <signal name="clicked" handler="position_left_button_clicked_cb" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkRadioButton" id="position_right_button">
-                                <property name="label" translatable="yes">Right</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="halign">center</property>
-                                <property name="valign">center</property>
-                                <property name="xalign">0</property>
-                                <property name="image_position">bottom</property>
-                                <property name="draw_indicator">True</property>
-                                <property name="group">position_bottom_button</property>
-                                <signal name="clicked" handler="position_right_button_clicked_cb" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
+                        <child type="label_item">
+                          <placeholder/>
                         </child>
                       </object>
                       <packing>
@@ -4951,9 +5067,6 @@
                         <property name="top_attach">2</property>
                         <property name="width">2</property>
                       </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
                     </child>
                   </object>
                   <packing>
@@ -5009,137 +5122,6 @@
         <property name="margin_bottom">24</property>
         <property name="orientation">vertical</property>
         <property name="spacing">24</property>
-        <child>
-          <object class="GtkFrame" id="panel_size_frame">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
-            <property name="shadow_type">in</property>
-            <child>
-              <object class="GtkListBox" id="panel_size_listbox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="selection_mode">none</property>
-                <child>
-                  <object class="GtkListBoxRow" id="panel_size_listboxrow">
-                    <property name="width_request">100</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <child>
-                      <object class="GtkGrid" id="panel_size_grid">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">12</property>
-                        <property name="margin_right">12</property>
-                        <property name="margin_top">6</property>
-                        <property name="margin_bottom">6</property>
-                        <property name="row_spacing">12</property>
-                        <property name="column_spacing">32</property>
-                        <child>
-                          <object class="GtkScale" id="panel_size_scale">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="valign">baseline</property>
-                            <property name="hexpand">True</property>
-                            <property name="adjustment">panel_size_adjustment</property>
-                            <property name="round_digits">0</property>
-                            <property name="digits">0</property>
-                            <property name="value_pos">right</property>
-                            <signal name="format-value" handler="panel_size_scale_format_value_cb" swapped="no"/>
-                            <signal name="value-changed" handler="panel_size_scale_value_changed_cb" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="panel_size_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Panel thickness
-(default is 48)</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="panel_length_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Panel length (%)
-(default is 100)</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkScale" id="panel_length_scale">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="valign">baseline</property>
-                            <property name="hexpand">True</property>
-                            <property name="adjustment">panel_length_adjustment</property>
-                            <property name="round_digits">0</property>
-                            <property name="digits">0</property>
-                            <property name="value_pos">right</property>
-                            <signal name="format-value" handler="panel_length_scale_format_value_cb" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBoxText" id="panel_anchor_combo">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="valign">center</property>
-                            <items>
-                              <item id="START" translatable="yes">Start</item>
-                              <item id="MIDDLE" translatable="yes">Middle</item>
-                              <item id="END" translatable="yes">End</item>
-                            </items>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="panel_anchor_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Anchor</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child type="label_item">
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkFrame" id="panel_style">
             <property name="visible">True</property>
@@ -5259,7 +5241,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
@@ -5538,7 +5520,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -5982,7 +5964,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -2,6 +2,11 @@
 <!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="appicon_margin_adjustment">
     <property name="lower">0.33</property>
     <property name="upper">1</property>
@@ -4799,6 +4804,69 @@
                         <property name="left_attach">0</property>
                         <property name="top_attach">2</property>
                         <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="panel_length_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="hexpand">False</property>
+                        <property name="label" translatable="yes">Length along screen edge, in percent</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="panel_length_spinbutton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="width_chars">5</property>
+                        <property name="text">100</property>
+                        <property name="adjustment">adjustment1</property>
+                        <property name="numeric">True</property>
+                        <property name="value">100</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="panel_anchor_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="hexpand">False</property>
+                        <property name="label" translatable="yes">Position along screen edge</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="panel_anchor_combo">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">center</property>
+                        <items>
+                          <item id="START" translatable="yes">Start</item>
+                          <item id="MIDDLE" translatable="yes">Middle</item>
+                          <item id="END" translatable="yes">End</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">4</property>
                       </packing>
                     </child>
                     <child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <object class="GtkAdjustment" id="adjustment1">
+  <object class="GtkAdjustment" id="panel_length_adjustment">
     <property name="upper">100</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
@@ -4807,69 +4807,6 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="panel_length_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_top">12</property>
-                        <property name="margin_bottom">12</property>
-                        <property name="hexpand">False</property>
-                        <property name="label" translatable="yes">Length along screen edge, in percent</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSpinButton" id="panel_length_spinbutton">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="margin_top">12</property>
-                        <property name="margin_bottom">12</property>
-                        <property name="width_chars">5</property>
-                        <property name="text">100</property>
-                        <property name="adjustment">adjustment1</property>
-                        <property name="numeric">True</property>
-                        <property name="value">100</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="panel_anchor_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_top">12</property>
-                        <property name="margin_bottom">12</property>
-                        <property name="hexpand">False</property>
-                        <property name="label" translatable="yes">Position along screen edge</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkComboBoxText" id="panel_anchor_combo">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="valign">center</property>
-                        <items>
-                          <item id="START" translatable="yes">Start</item>
-                          <item id="MIDDLE" translatable="yes">Middle</item>
-                          <item id="END" translatable="yes">End</item>
-                        </items>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
-                      </packing>
-                    </child>
-                    <child>
                       <placeholder/>
                     </child>
                   </object>
@@ -4927,13 +4864,13 @@
         <property name="orientation">vertical</property>
         <property name="spacing">24</property>
         <child>
-          <object class="GtkFrame" id="panel_style">
+          <object class="GtkFrame" id="panel_size_frame">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="label_xalign">0</property>
             <property name="shadow_type">in</property>
             <child>
-              <object class="GtkListBox" id="panel_style_listbox">
+              <object class="GtkListBox" id="panel_size_listbox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="selection_mode">none</property>
@@ -4950,20 +4887,8 @@
                         <property name="margin_right">12</property>
                         <property name="margin_top">6</property>
                         <property name="margin_bottom">6</property>
+                        <property name="row_spacing">12</property>
                         <property name="column_spacing">32</property>
-                        <child>
-                          <object class="GtkLabel" id="panel_size_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Panel Size
-(default is 48)</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
                         <child>
                           <object class="GtkScale" id="panel_size_scale">
                             <property name="visible">True</property>
@@ -4982,10 +4907,104 @@
                             <property name="top_attach">0</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkLabel" id="panel_size_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Panel thickness
+(default is 48)</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="panel_length_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Panel length (%)
+(default is 100)</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScale" id="panel_length_scale">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="valign">baseline</property>
+                            <property name="hexpand">True</property>
+                            <property name="adjustment">panel_length_adjustment</property>
+                            <property name="round_digits">0</property>
+                            <property name="digits">0</property>
+                            <property name="value_pos">right</property>
+                            <signal name="format-value" handler="panel_length_scale_format_value_cb" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="panel_anchor_combo">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="valign">center</property>
+                            <items>
+                              <item id="START" translatable="yes">Start</item>
+                              <item id="MIDDLE" translatable="yes">Middle</item>
+                              <item id="END" translatable="yes">End</item>
+                            </items>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="panel_anchor_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Anchor</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>
                 </child>
+              </object>
+            </child>
+            <child type="label_item">
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame" id="panel_style">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkListBox" id="panel_style_listbox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selection_mode">none</property>
                 <child>
                   <object class="GtkListBoxRow" id="margin_listboxrow">
                     <property name="width_request">100</property>
@@ -5094,7 +5113,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -5373,7 +5392,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -5817,7 +5836,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/appIcons.js
+++ b/appIcons.js
@@ -47,6 +47,7 @@ const Workspace = imports.ui.workspace;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 const Panel = Me.imports.panel;
+const PanelSettings = Me.imports.panelSettings;
 const Taskbar = Me.imports.taskbar;
 const Progress = Me.imports.progress;
 const _ = imports.gettext.domain(Utils.TRANSLATION_DOMAIN).gettext;
@@ -573,9 +574,9 @@ var taskbarAppIcon = Utils.defineClass({
     },
 
     _setAppIconPadding: function() {
-        let padding = getIconPadding();
+        let padding = getIconPadding(this.dtpPanel.monitor.index);
         let margin = Me.settings.get_int('appicon-margin');
-        
+
         this.actor.set_style('padding:' + (this.dtpPanel.checkIfVertical() ? margin + 'px 0' : '0 ' + margin + 'px;'));
         this._iconContainer.set_style('padding: ' + padding + 'px;');
     },
@@ -1365,8 +1366,8 @@ function cssHexTocssRgba(cssHex, opacity) {
     return 'rgba(' + [r, g, b].join(',') + ',' + opacity + ')';
 }
 
-function getIconPadding() {
-    let panelSize = Me.settings.get_int('panel-size');
+function getIconPadding(monitorIndex) {
+    let panelSize = PanelSettings.getPanelSize(Me.settings, monitorIndex);
     let padding = Me.settings.get_int('appicon-padding');
     let availSize = panelSize - Taskbar.MIN_ICON_SIZE - panelSize % 2;
 
@@ -1684,7 +1685,7 @@ var ShowAppsIconWrapper = Utils.defineClass({
     },
 
     setShowAppsPadding: function() {
-        let padding = getIconPadding(); 
+        let padding = getIconPadding(this.realShowAppsIcon._dtpPanel.monitor.index);
         let sidePadding = Me.settings.get_int('show-apps-icon-side-padding');
         let isVertical = this.realShowAppsIcon._dtpPanel.checkIfVertical();
 

--- a/panel.js
+++ b/panel.js
@@ -36,6 +36,7 @@ const AppIcons = Me.imports.appIcons;
 const Utils = Me.imports.utils;
 const Taskbar = Me.imports.taskbar;
 const Pos = Me.imports.panelPositions;
+const PanelSettings = Me.imports.panelSettings;
 const PanelStyle = Me.imports.panelStyle;
 const Lang = imports.lang;
 const Main = imports.ui.main;
@@ -535,8 +536,7 @@ var dtpPanel = Utils.defineClass({
     },
 
     getPosition: function() {
-        //for now, use the previous "global" position setting as default. The 'panel-position' should be deleted in the future 
-        let position = this.panelManager.panelPositions[this.monitor.index] || Me.settings.get_string('panel-position');
+        let position = PanelSettings.getPanelPosition(Me.settings, this.monitor.index);
 
         if (position == Pos.TOP) {
             return St.Side.TOP;
@@ -652,12 +652,12 @@ var dtpPanel = Utils.defineClass({
 
     _bindSettingsChanges: function() {
         let isVertical = this.checkIfVertical();
-        
+
         this._signalsHandler.add(
             [
                 Me.settings,
                 [
-                    'changed::panel-size',
+                    'changed::panel-sizes',
                     'changed::group-apps'
                 ],
                 () => this._resetGeometry()
@@ -814,14 +814,15 @@ var dtpPanel = Utils.defineClass({
         let topPadding = panelBoxTheme.get_padding(St.Side.TOP);
         let tbPadding = topPadding + panelBoxTheme.get_padding(St.Side.BOTTOM);
         let position = this.getPosition();
-        let length = Me.settings.get_int('panel-length') / 100;
-        let anchor = Me.settings.get_string('panel-anchor');
+        let length = PanelSettings.getPanelLength(Me.settings, this.monitor.index) / 100;
+        let anchor = PanelSettings.getPanelAnchor(Me.settings, this.monitor.index);
         let anchorPlaceOnMonitor = 0;
         let gsTopPanelOffset = 0;
         let x = 0, y = 0;
         let w = 0, h = 0;
 
-        this.dtpSize = Me.settings.get_int('panel-size') * scaleFactor;
+        const panelSize = PanelSettings.getPanelSize(Me.settings, this.monitor.index);
+        this.dtpSize = panelSize * scaleFactor;
 
         if (Me.settings.get_boolean('stockgs-keep-top-panel') && Main.layoutManager.primaryMonitor == this.monitor) {
             gsTopPanelOffset = Main.layoutManager.panelBox.height - topPadding;

--- a/panel.js
+++ b/panel.js
@@ -798,6 +798,9 @@ var dtpPanel = Utils.defineClass({
         let topPadding = panelBoxTheme.get_padding(St.Side.TOP);
         let tbPadding = topPadding + panelBoxTheme.get_padding(St.Side.BOTTOM);
         let position = this.getPosition();
+        let length = Me.settings.get_int('panel-length') / 100;
+        let anchor = Me.settings.get_string('panel-anchor');
+        let anchorPlaceOnMonitor = 0;
         let gsTopPanelOffset = 0;
         let x = 0, y = 0;
         let w = 0, h = 0;
@@ -819,13 +822,13 @@ var dtpPanel = Utils.defineClass({
             this.varCoord = { c1: 'y1', c2: 'y2' };
 
             w = this.dtpSize;
-            h = this.monitor.height - tbPadding - gsTopPanelOffset;
+            h = this.monitor.height * length - tbPadding - gsTopPanelOffset;
         } else {
             this.sizeFunc = 'get_preferred_width';
             this.fixedCoord = { c1: 'y1', c2: 'y2' };
             this.varCoord = { c1: 'x1', c2: 'x2' };
 
-            w = this.monitor.width - lrPadding;
+            w = this.monitor.width * length - lrPadding;
             h = this.dtpSize;
         }
 
@@ -836,8 +839,28 @@ var dtpPanel = Utils.defineClass({
             x = this.monitor.x + this.monitor.width - this.dtpSize - lrPadding;
             y = this.monitor.y + gsTopPanelOffset;
         } else { //BOTTOM
-            x = this.monitor.x; 
+            x = this.monitor.x;
             y = this.monitor.y + this.monitor.height - this.dtpSize - tbPadding;
+        }
+
+        if (this.checkIfVertical()) {
+            if (anchor === Pos.MIDDLE) {
+                anchorPlaceOnMonitor = (this.monitor.height - h) / 2;
+            } else if (anchor === Pos.END) {
+                anchorPlaceOnMonitor = this.monitor.height - h;
+            } else { // Pos.START
+                anchorPlaceOnMonitor = 0;
+            }
+            y = y + anchorPlaceOnMonitor;
+        } else {
+            if (anchor === Pos.MIDDLE) {
+                anchorPlaceOnMonitor = (this.monitor.width - w) / 2;
+            } else if (anchor === Pos.END) {
+                anchorPlaceOnMonitor = this.monitor.width - w;
+            } else { // Pos.START
+                anchorPlaceOnMonitor = 0;
+            }
+            x = x + anchorPlaceOnMonitor;
         }
 
         return {

--- a/panelManager.js
+++ b/panelManager.js
@@ -235,6 +235,8 @@ var dtpPanelManager = Utils.defineClass({
                     'changed::multi-monitors',
                     'changed::isolate-monitors',
                     'changed::panel-positions',
+                    'changed::panel-length',
+                    'changed::panel-anchor',
                     'changed::stockgs-keep-top-panel'
                 ],
                 () => this._reset()

--- a/panelManager.js
+++ b/panelManager.js
@@ -30,7 +30,7 @@
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Overview = Me.imports.overview;
 const Panel = Me.imports.panel;
-const Pos = Me.imports.panelPositions;
+const PanelSettings = Me.imports.panelSettings;
 const Proximity = Me.imports.proximity;
 const Taskbar = Me.imports.taskbar;
 const Utils = Me.imports.utils;
@@ -72,8 +72,7 @@ var dtpPanelManager = Utils.defineClass({
 
     enable: function(reset) {
         let dtpPrimaryIndex = Me.settings.get_int('primary-monitor');
-        
-        this.panelPositions = Pos.getSettingsPositions(Me.settings, 'panel-positions');
+
         this.dtpPrimaryMonitor = Main.layoutManager.monitors[dtpPrimaryIndex] || Main.layoutManager.primaryMonitor;
         this.proximityManager = new Proximity.ProximityManager();
 
@@ -240,8 +239,8 @@ var dtpPanelManager = Utils.defineClass({
                     'changed::multi-monitors',
                     'changed::isolate-monitors',
                     'changed::panel-positions',
-                    'changed::panel-length',
-                    'changed::panel-anchor',
+                    'changed::panel-lengths',
+                    'changed::panel-anchors',
                     'changed::stockgs-keep-top-panel'
                 ],
                 () => this._reset()
@@ -437,7 +436,7 @@ var dtpPanelManager = Utils.defineClass({
     },
 
     _updatePanelElementPositions: function() {
-        this.panelsElementPositions = Pos.getSettingsPositions(Me.settings, 'panel-element-positions');
+        this.panelsElementPositions = PanelSettings.getSettingsJson(Me.settings, 'panel-element-positions');
         this.allPanels.forEach(p => p.updateElementPositions());
     },
 

--- a/panelPositions.js
+++ b/panelPositions.js
@@ -56,18 +56,6 @@ var optionDialogFunctions = {};
 optionDialogFunctions[SHOW_APPS_BTN] = '_showShowAppsButtonOptions';
 optionDialogFunctions[DESKTOP_BTN] = '_showDesktopButtonOptions';
 
-function getSettingsPositions(settings, setting) {
-    var positions = null;
-
-    try {
-        positions = JSON.parse(settings.get_string(setting));
-    } catch(e) {
-        log('Error parsing positions: ' + e.message);
-    }
-
-    return positions;
-}
-
 function checkIfCentered(position) {
     return position == CENTERED || position == CENTERED_MONITOR;
 }

--- a/panelPositions.js
+++ b/panelPositions.js
@@ -35,6 +35,10 @@ var BOTTOM = 'BOTTOM';
 var LEFT = 'LEFT';
 var RIGHT = 'RIGHT';
 
+var START = 'START';
+var MIDDLE = 'MIDDLE';
+var END = 'END';
+
 var defaults = [
     { element: SHOW_APPS_BTN,   visible: true,     position: STACKED_TL },
     { element: ACTIVITIES_BTN,  visible: false,    position: STACKED_TL },

--- a/panelSettings.js
+++ b/panelSettings.js
@@ -1,0 +1,112 @@
+/*
+ * This file is part of the Dash-To-Panel extension for Gnome 3
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Pos = Me.imports.panelPositions;
+
+/** Return object representing a settings value that is stored as JSON. */
+function getSettingsJson(settings, setting) {
+    try {
+        return JSON.parse(settings.get_string(setting));
+    } catch(e) {
+        log('Error parsing positions: ' + e.message);
+    }
+}
+/** Write value object as JSON to setting in settings. */
+function setSettingsJson(settings, setting, value) {
+    try {
+        const json = JSON.stringify(value);
+        settings.set_string(setting, json);
+    } catch(e) {
+        log('Error serializing setting: ' + e.message);
+    }
+}
+
+/** Returns size of panel on a specific monitor, in pixels. */
+function getPanelSize(settings, monitorIndex) {
+    const sizes = getSettingsJson(settings, 'panel-sizes');
+    // Pull in deprecated setting if panel-sizes does not have setting for monitor.
+    const fallbackSize = settings.get_int('panel-size');
+    const theDefault = 48;
+    return sizes[monitorIndex] || fallbackSize || theDefault;
+}
+
+function setPanelSize(settings, monitorIndex, value) {
+    if (!(Number.isInteger(value) && value <= 128 && value >= 16)) {
+        log(`Not setting invalid panel size: ${value}`);
+        return;
+    }
+    let sizes = getSettingsJson(settings, 'panel-sizes');
+    sizes[monitorIndex] = value;
+    setSettingsJson(settings, 'panel-sizes', sizes);
+}
+
+/**
+ * Returns length of panel on a specific monitor, as a whole number percent,
+ * from settings. e.g. 100
+ */
+function getPanelLength(settings, monitorIndex) {
+    const lengths = getSettingsJson(settings, 'panel-lengths');
+    const theDefault = 100;
+    return lengths[monitorIndex] || theDefault;
+}
+
+function setPanelLength(settings, monitorIndex, value) {
+    if (!(Number.isInteger(value) && value <= 100 && value >= 0)) {
+        log(`Not setting invalid panel length: ${value}`);
+        return;
+    }
+    let lengths = getSettingsJson(settings, 'panel-lengths');
+    lengths[monitorIndex] = value;
+    setSettingsJson(settings, 'panel-lengths', lengths);
+}
+
+/** Returns position of panel on a specific monitor. */
+function getPanelPosition(settings, monitorIndex) {
+    const positions = getSettingsJson(settings, 'panel-positions');
+    const fallbackPosition = settings.get_string('panel-position');
+    const theDefault = Pos.BOTTOM;
+    return positions[monitorIndex] || fallbackPosition || theDefault;
+}
+
+function setPanelPosition(settings, monitorIndex, value) {
+    if (!(value === Pos.TOP || value === Pos.BOTTOM || value === Pos.LEFT
+        || value === Pos.RIGHT)) {
+        log(`Not setting invalid panel position: ${value}`);
+        return;
+    }
+    const positions = getSettingsJson(settings, 'panel-positions');
+    positions[monitorIndex] = value;
+    setSettingsJson(settings, 'panel-positions', positions);
+}
+
+/** Returns anchor location of panel on a specific monitor. */
+function getPanelAnchor(settings, monitorIndex) {
+    const anchors = getSettingsJson(settings, 'panel-anchors');
+    const theDefault = Pos.MIDDLE;
+    return anchors[monitorIndex] || theDefault;
+}
+
+function setPanelAnchor(settings, monitorIndex, value) {
+    if (!(value === Pos.START || value === Pos.MIDDLE || value === Pos.END)) {
+        log(`Not setting invalid panel anchor: ${value}`);
+        return;
+    }
+    const anchors = getSettingsJson(settings, 'panel-anchors');
+    anchors[monitorIndex] = value;
+    setSettingsJson(settings, 'panel-anchors', anchors);
+}

--- a/prefs.js
+++ b/prefs.js
@@ -770,7 +770,24 @@ const Settings = new Lang.Class({
         if (this.monitors.length === 1) {
             this._builder.get_object('multimon_multi_switch').set_sensitive(false);
         }
-        
+
+        // Length and position along screen edge
+
+        // Minimum length could be 0, but a higher value may help prevent confusion about where the panel went.
+        let panel_length_min=10
+        let panel_length_max=100
+        let panel_length_spinbutton = this._builder.get_object('panel_length_spinbutton');
+        panel_length_spinbutton.set_range(panel_length_min, panel_length_max);
+        panel_length_spinbutton.set_value(this._settings.get_int('panel-length'));
+        this._builder.get_object('panel_length_spinbutton').connect('value-changed', Lang.bind (this, function(widget) {
+            this._settings.set_int('panel-length', widget.get_value());
+        }));
+
+        this._builder.get_object('panel_anchor_combo').set_active_id(this._settings.get_string('panel-anchor'));
+        this._builder.get_object('panel_anchor_combo').connect('changed', Lang.bind (this, function(widget) {
+            this._settings.set_string('panel-anchor', widget.get_active_id());
+        }));
+
         //dynamic opacity
         this._settings.bind('trans-use-custom-bg',
                             this._builder.get_object('trans_bg_switch'),

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -40,11 +40,6 @@
     <value value='2' nick='LEFT'/>
     <value value='3' nick='RIGHT'/>
   </enum>
-  <enum id='org.gnome.shell.extensions.dash-to-panel.anchor'>
-    <value value='0' nick='START'/>
-    <value value='1' nick='MIDDLE'/>
-    <value value='2' nick='END'/>
-  </enum>
   <enum id='org.gnome.shell.extensions.dash-to-panel.proximityBehavior'>
     <value value='0' nick='ALL_WINDOWS'/>
     <value value='1' nick='FOCUSED_WINDOWS'/>
@@ -74,7 +69,7 @@
     </key>
     <key name="panel-position" enum="org.gnome.shell.extensions.dash-to-panel.position">
       <default>'BOTTOM'</default>
-      <summary>Panel position</summary>
+      <summary>Panel position (Deprecated)</summary>
       <description>Panel is shown on the Bottom or Top of the screen.</description>
     </key>
     <key name="panel-element-positions-monitors-sync" type="b">
@@ -92,19 +87,24 @@
       <summary>Panel element positions</summary>
       <description>Panel element positions (JSON).</description>
     </key>
-    <key type="i" name="panel-length">
-      <default>100</default>
-      <summary>Percentage of screen edge for panel to span</summary>
-      <description>Length of the panel, in percent.</description>
+    <key type="s" name="panel-lengths">
+      <default>'{}'</default>
+      <summary>Percentages of screen edge for panel to span</summary>
+      <description>Length of the panels, in percent (JSON).</description>
     </key>
-    <key name="panel-anchor" enum="org.gnome.shell.extensions.dash-to-panel.anchor">
-      <default>'MIDDLE'</default>
-      <summary>Position along screen edge</summary>
-      <description>Where to show the panel if it is not the full length of the screen edge.</description>
+    <key type="s" name="panel-anchors">
+      <default>'{}'</default>
+      <summary>Positions along screen edge</summary>
+      <description>Where to show the panels if it is not the full length of the screen edge (JSON).</description>
+    </key>
+    <key type="s" name="panel-sizes">
+      <default>'{}'</default>
+      <summary>Panel sizes</summary>
+      <description>Sizes of panels, in pixels.</description>
     </key>
     <key type="i" name="panel-size">
       <default>48</default>
-      <summary>Panel size</summary>
+      <summary>Panel size (Deprecated)</summary>
       <description>Set the size of the panel.</description>
     </key>
     <key type="b" name="desktop-line-use-custom-color">

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -95,7 +95,7 @@
     <key type="i" name="panel-length">
       <default>100</default>
       <summary>Percentage of screen edge for panel to span</summary>
-      <description>Set the length of the panel, in percent. Horizontal or vertical, according to panel orientation.</description>
+      <description>Length of the panel, in percent.</description>
     </key>
     <key name="panel-anchor" enum="org.gnome.shell.extensions.dash-to-panel.anchor">
       <default>'MIDDLE'</default>

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -40,6 +40,11 @@
     <value value='2' nick='LEFT'/>
     <value value='3' nick='RIGHT'/>
   </enum>
+  <enum id='org.gnome.shell.extensions.dash-to-panel.anchor'>
+    <value value='0' nick='START'/>
+    <value value='1' nick='MIDDLE'/>
+    <value value='2' nick='END'/>
+  </enum>
   <enum id='org.gnome.shell.extensions.dash-to-panel.proximityBehavior'>
     <value value='0' nick='ALL_WINDOWS'/>
     <value value='1' nick='FOCUSED_WINDOWS'/>
@@ -86,6 +91,16 @@
       <default>'{}'</default>
       <summary>Panel element positions</summary>
       <description>Panel element positions (JSON).</description>
+    </key>
+    <key type="i" name="panel-length">
+      <default>100</default>
+      <summary>Percentage of screen edge for panel to span</summary>
+      <description>Set the length of the panel, in percent. Horizontal or vertical, according to panel orientation.</description>
+    </key>
+    <key name="panel-anchor" enum="org.gnome.shell.extensions.dash-to-panel.anchor">
+      <default>'MIDDLE'</default>
+      <summary>Position along screen edge</summary>
+      <description>Where to show the panel if it is not the full length of the screen edge.</description>
     </key>
     <key type="i" name="panel-size">
       <default>48</default>

--- a/taskbar.js
+++ b/taskbar.js
@@ -46,6 +46,7 @@ const Workspace = imports.ui.workspace;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const AppIcons = Me.imports.appIcons;
 const Panel = Me.imports.panel;
+const PanelSettings = Me.imports.panelSettings;
 const Utils = Me.imports.utils;
 const WindowPreview = Me.imports.windowPreview;
 
@@ -700,7 +701,8 @@ var taskbar = Utils.defineClass({
     },
 
     _adjustIconSize: function() {
-        let panelSize = Me.settings.get_int('panel-size');
+        const thisMonitorIndex = this.dtpPanel.monitor.index;
+        let panelSize = PanelSettings.getPanelSize(Me.settings, thisMonitorIndex);
         let availSize = panelSize - Me.settings.get_int('appicon-padding') * 2;
         let minIconSize = MIN_ICON_SIZE + panelSize % 2;
 

--- a/utils.js
+++ b/utils.js
@@ -23,7 +23,7 @@
 
 const Clutter = imports.gi.Clutter;
 const Config = imports.misc.config;
-const GdkPixbuf = imports.gi.GdkPixbuf
+const GdkPixbuf = imports.gi.GdkPixbuf;
 const Gi = imports._gi;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -144,7 +144,7 @@ var PreviewMenu = Utils.defineClass({
             [
                 Me.settings,
                 [
-                    'changed::panel-size',
+                    'changed::panel-sizes',
                     'changed::window-preview-size',
                     'changed::window-preview-padding',
                     'changed::window-preview-show-title'


### PR DESCRIPTION
Set the length of the panel according to a specified percent value, so
it can span only part of the screen edge.

Position the panel at the start, middle, or end of the screen edge, as
specified.

Tests okay with multiple monitors.

May also satisfy home-sweet-gnome/dash-to-panel#726