### PR TITLE
Settings.ui: remove show_desktop GtkColorButton property

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -4120,7 +4120,6 @@
                          <property name="receives_default">True</property>
                          <property name="halign">end</property>
                          <property name="use_alpha">True</property>
-                         <property name="show_editor">True</property>
                       </object>
                       <packing>
                          <property name="expand">False</property>


### PR DESCRIPTION
The GtkColorButton “show-editor” property was introduced in Gtk 3.20 so it make preferences non-openable in GS 3.18.

Fix cfab668
Related to #1101
@hlechner