### PR TITLE
Fix drag and drop from the applications view to the taskbar

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -150,7 +150,7 @@ var taskbarAppIcon = Utils.defineClass({
         
         this._container = new St.Widget({ style_class: 'dtp-container', layout_manager: new Clutter.BinLayout() });
         this._dotsContainer = new St.Widget({ layout_manager: new Clutter.BinLayout() });
-        this._dtpIconContainer = new St.Widget({ layout_manager: new Clutter.BinLayout(), style: this.getIconContainerStyle() });
+        this._dtpIconContainer = new St.Widget({ layout_manager: new Clutter.BinLayout(), style: getIconContainerStyle(panel.checkIfVertical()) });
 
         this.actor.remove_actor(this._iconContainer);
         
@@ -1224,19 +1224,6 @@ var taskbarAppIcon = Utils.defineClass({
 
     getAppIconInterestingWindows: function(isolateMonitors) {
         return getInterestingWindows(this.app, this.dtpPanel.monitor, isolateMonitors);
-    },
-
-    getIconContainerStyle: function() {
-        let style = 'padding: ';
-        let isVertical = this.dtpPanel.checkIfVertical();
-    
-        if (Me.settings.get_boolean('group-apps')) {
-            style += (isVertical ? '0;' : '0 ' + DEFAULT_PADDING_SIZE + 'px;');
-        } else {
-            style += (isVertical ? '' : '0 ') + DEFAULT_PADDING_SIZE + 'px;';
-        }
-    
-        return style;
     }
 });
 taskbarAppIcon.prototype.scaleAndFade = taskbarAppIcon.prototype.undoScaleAndFade = () => {};
@@ -1884,4 +1871,16 @@ adjustMenuRedisplay(MyShowAppsIconMenu.prototype);
 
 function adjustMenuRedisplay(menuProto) {
     menuProto[menuRedisplayFunc] = function() { this._dtpRedisplay(menuRedisplayFunc) };
+}
+
+var getIconContainerStyle = function(isVertical) {
+    let style = 'padding: ';
+
+    if (Me.settings.get_boolean('group-apps')) {
+        style += (isVertical ? '0;' : '0 ' + DEFAULT_PADDING_SIZE + 'px;');
+    } else {
+        style += (isVertical ? '' : '0 ') + DEFAULT_PADDING_SIZE + 'px;';
+    }
+
+    return style;
 }

--- a/taskbar.js
+++ b/taskbar.js
@@ -948,14 +948,14 @@ var taskbar = Utils.defineClass({
             return DND.DragMotionResult.NO_DROP;
 
         let sourceActor = source instanceof St.Widget ? source : source.actor;
+        let isVertical = this.dtpPanel.checkIfVertical();
 
         if (!this._box.contains(sourceActor) && !source._dashItemContainer) {
             //not an appIcon of the taskbar, probably from the applications view
-            source._dashItemContainer = new DragPlaceholderItem(source, this.iconSize);
+            source._dashItemContainer = new DragPlaceholderItem(source, this.iconSize, isVertical);
             this._box.insert_child_above(source._dashItemContainer, null);
         }
-        
-        let isVertical = this.dtpPanel.checkIfVertical();
+
         let sizeProp = isVertical ? 'height' : 'width';
         let posProp = isVertical ? 'y' : 'x';
         let pos = isVertical ? y : x;
@@ -1220,8 +1220,8 @@ var DragPlaceholderItem = Utils.defineClass({
     Name: 'DashToPanel-DragPlaceholderItem',
     Extends: St.Widget,
 
-    _init: function(appIcon, iconSize) {
-        this.callParent('_init', { style: appIcon.getIconContainerStyle(), layout_manager: new Clutter.BinLayout() });
+    _init: function(appIcon, iconSize, isVertical) {
+        this.callParent('_init', { style: AppIcons.getIconContainerStyle(isVertical), layout_manager: new Clutter.BinLayout() });
 
         this.child = { _delegate: appIcon };
 


### PR DESCRIPTION
Dragging an icon from the applications view to the taskbar gives the error `appIcon.getIconContainerStyle is not a function`. This PR fixes this and makes the drag and drop work again.

Tested with GNOME Shell 3.36.6 (Arch Linux)