### PR TITLE
Hide appIcon in the taskbar when in drag and drop

### DIFF
--- a/taskbar.js
+++ b/taskbar.js
@@ -481,7 +481,7 @@ var taskbar = Utils.defineClass({
         if (app == null)
             return DND.DragMotionResult.CONTINUE;
 
-         let showAppsHovered = this._showAppsIcon.contains(dragEvent.targetActor);
+        let showAppsHovered = this._showAppsIcon.contains(dragEvent.targetActor);
 
         if (showAppsHovered)
             this._showAppsIcon.setDragApp(app);
@@ -555,7 +555,7 @@ var taskbar = Utils.defineClass({
         if (appIcon._draggable) {
             appIcon._draggable.connect('drag-begin',
                                        Lang.bind(this, function() {
-                                           appIcon.actor.opacity = 50;
+                                           appIcon.actor.opacity = 0;
                                        }));
             appIcon._draggable.connect('drag-end',
                                        Lang.bind(this, function() {


### PR DESCRIPTION
In an effort of making the extension more coherent with gnome-shell, I propose this change that is coherent to how Gnome 3.38 manages the drag and drop in the applications view. Basically in Gnome 3.38, when dragging an icon, the icon starts following the cursor and then it creates "empty spots" in relation where the cursor is to show where the app will be placed.

The extension already makes the icons less opaque when using drag and drop, so just setting them to be invisible does the trick.
I think that this change also makes the drag and drop cleaner.