### PR TITLE
implement always show on primary setting

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -6267,6 +6267,32 @@
                             <property name="top_attach">1</property>
                           </packing>
                         </child>
+                          <child>
+                          <object class="GtkSwitch" id="multimon_multi_always_show_primary_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="multimon_multi_always_show_primary_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Always show on primary</property>
+                            <property name="use_markup">True</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/appIcons.js
+++ b/appIcons.js
@@ -105,6 +105,8 @@ let menuRedisplayFunc = !!AppDisplay.AppIconMenu.prototype._rebuildMenu ? '_rebu
  *
  */
 
+let primaryMonitor = 0;
+
 var taskbarAppIcon = Utils.defineClass({
     Name: 'DashToPanel.TaskbarAppIcon',
     Extends: AppDisplay.AppIcon,
@@ -261,6 +263,10 @@ var taskbarAppIcon = Utils.defineClass({
         this._progressIndicator = new Progress.ProgressIndicator(this, panel.progressManager);
 
         this._numberOverlay();
+
+        if(this.dtpPanel.isPrimary) {
+            primaryMonitor = this.dtpPanel.monitor;
+        }
     },
 
     getDragActor: function() {
@@ -1348,9 +1354,11 @@ function getInterestingWindows(app, monitor, isolateMonitors) {
         });
 
     if (monitor && Me.settings.get_boolean('multi-monitors') && (isolateMonitors || Me.settings.get_boolean('isolate-monitors'))) {
-        windows = windows.filter(function(w) {
-            return w.get_monitor() == monitor.index;
-        });
+        if(!(Me.settings.get_boolean('always-show-on-primary') && monitor == primaryMonitor)) {
+            windows = windows.filter(function(w) {
+                return w.get_monitor() == monitor.index;
+            });
+        }
     }
     
     return windows;

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
 "extension-id": "dash-to-panel",
 "uuid": "dash-to-panel@jderose9.github.com",
 "name": "Dash to Panel",
-"description": "An icon taskbar for the Gnome Shell. This extension moves the dash into the gnome main panel so that the application launchers and system tray are combined into a single panel, similar to that found in KDE Plasma and Windows 7+. A separate dock is no longer needed for easy access to running and favorited applications.\n\nFor a more traditional experience, you may also want to use Tweak Tool to enable Windows > Titlebar Buttons > Minimize & Maximize.\n\nFor the best support, please report any issues on Github. Dash-to-panel is developed and maintained by @jderose9 and @charlesg99.",
+"description": "SM - An icon taskbar for the Gnome Shell. This extension moves the dash into the gnome main panel so that the application launchers and system tray are combined into a single panel, similar to that found in KDE Plasma and Windows 7+. A separate dock is no longer needed for easy access to running and favorited applications.\n\nFor a more traditional experience, you may also want to use Tweak Tool to enable Windows > Titlebar Buttons > Minimize & Maximize.\n\nFor the best support, please report any issues on Github. Dash-to-panel is developed and maintained by @jderose9 and @charlesg99.",
 "shell-version": [ "3.18", "3.20", "3.22", "3.24", "3.26", "3.28", "3.30", "3.32", "3.34", "3.36" ],
 "url": "https://github.com/jderose9/dash-to-panel",
 "gettext-domain": "dash-to-panel",

--- a/panelManager.js
+++ b/panelManager.js
@@ -239,6 +239,7 @@ var dtpPanelManager = Utils.defineClass({
                     'changed::primary-monitor',
                     'changed::multi-monitors',
                     'changed::isolate-monitors',
+                    'changed::always-show-on-primary',
                     'changed::panel-positions',
                     'changed::stockgs-keep-top-panel'
                 ],

--- a/prefs.js
+++ b/prefs.js
@@ -1394,7 +1394,12 @@ const Settings = new Lang.Class({
                             this._builder.get_object('multimon_multi_isolate_monitor_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
-
+                            
+        this._settings.bind('always-show-on-primary',
+                            this._builder.get_object('multimon_multi_always_show_primary_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+                            
         this._settings.bind('overview-click-to-exit',
                             this._builder.get_object('clicktoexit_switch'),
                             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -612,6 +612,11 @@
       <summary>Provide monitor isolation</summary>
       <description>Dash shows only windows from the current monitor</description>
     </key>
+    <key type="b" name="always-show-on-primary">
+      <default>false</default>
+      <summary>Always show icons on primary monitor</summary>
+      <description>When using monitor isolation, always show running apps on the primary monitor</description>
+    </key>
     <key type="b" name="show-favorites-all-monitors">
       <default>true</default>
       <summary>Display the favorites on all monitors</summary>


### PR DESCRIPTION
Implement option to always show all apps on the primary panel when isolate monitors is turned on