### PR TITLE
Animate app icons when urgent property is set

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -110,12 +110,13 @@ var taskbarAppIcon = Utils.defineClass({
     Extends: AppDisplay.AppIcon,
     ParentConstrParams: [[0, 'app'], [2]],
 
-    _init: function(appInfo, panel, iconParams, previewMenu) {
+    _init: function(appInfo, panel, iconParams, previewMenu, iconAnimator) {
         this.dtpPanel = panel;
         this._nWindows = 0;
         this.window = appInfo.window;
         this.isLauncher = appInfo.isLauncher;
         this._previewMenu = previewMenu;
+        this.iconAnimator = iconAnimator;
 
         this._timeoutsHandler = new Utils.TimeoutsHandler();
 

--- a/progress.js
+++ b/progress.js
@@ -176,6 +176,7 @@ var AppProgress = Utils.defineClass({
         this._countVisible = false;
         this._progress = 0.0;
         this._progressVisible = false;
+        this._urgent = false;
         this.update(properties);
     },
 
@@ -231,6 +232,17 @@ var AppProgress = Utils.defineClass({
         }
     },
 
+    urgent: function() {
+        return this._urgent;
+    },
+
+    setUrgent: function(urgent) {
+        if (this._urgent != urgent) {
+            this._urgent = urgent;
+            this.emit('urgent-changed', this._urgent);
+        }
+    },
+
     setDBusName: function(dbusName) {
         if (this._dbusName != dbusName) {
             let oldName = this._dbusName;
@@ -246,6 +258,7 @@ var AppProgress = Utils.defineClass({
             this.setCountVisible(other.countVisible());
             this.setProgress(other.progress());
             this.setProgressVisible(other.progressVisible())
+            this.setUrgent(other.urgent());
         } else {
             for (let property in other) {
                 if (other.hasOwnProperty(property)) {
@@ -257,6 +270,8 @@ var AppProgress = Utils.defineClass({
                         this.setProgress(other[property].get_double());
                     } else if (property == 'progress-visible') {
                         this.setProgressVisible(Me.settings.get_boolean('progress-show-bar') && other[property].get_boolean());
+                    } else if (property == 'urgent') {
+                        this.setUrgent(other[property].get_boolean());
                     } else {
                         // Not implemented yet
                     }
@@ -513,6 +528,7 @@ var ProgressIndicator = Utils.defineClass({
             this.toggleNotificationBadge(false);
             this.setProgress(0);
             this.toggleProgressOverlay(false);
+            this.setUrgent(false);
         }
     },
 
@@ -547,6 +563,12 @@ var ProgressIndicator = Utils.defineClass({
             (appProgress, value) => {
                 this.toggleProgressOverlay(value);
             }
+        ], [
+            appProgress,
+            'urgent-changed',
+            (appProgress, value) => {
+                this.setUrgent(value)
+            }
         ]);
 
         this.setNotificationBadge(appProgress.count());
@@ -554,5 +576,23 @@ var ProgressIndicator = Utils.defineClass({
         this.setProgress(appProgress.progress());
         this.toggleProgressOverlay(appProgress.progressVisible());
 
+        this._isUrgent = false;
+    },
+
+    setUrgent(urgent) {
+        const icon = this._source.icon._iconBin;
+        if (urgent) {
+            if (!this._isUrgent) {
+                icon.set_pivot_point(0.5, 0.5);
+                this._source.iconAnimator.addAnimation(icon, 'dance');
+                this._isUrgent = true;
+            }
+        } else {
+            if (this._isUrgent) {
+                this._source.iconAnimator.removeAnimation(icon, 'dance');
+                this._isUrgent = false;
+            }
+            icon.rotation_angle_z = 0;
+        }
     }
 });

--- a/taskbar.js
+++ b/taskbar.js
@@ -46,6 +46,7 @@ const Workspace = imports.ui.workspace;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const AppIcons = Me.imports.appIcons;
 const Panel = Me.imports.panel;
+const PanelManager = Me.imports.panelManager;
 const Utils = Me.imports.utils;
 const WindowPreview = Me.imports.windowPreview;
 
@@ -241,6 +242,8 @@ var taskbar = Utils.defineClass({
 
         this._appSystem = Shell.AppSystem.get_default();
 
+        this.iconAnimator = new PanelManager.IconAnimator(this.dtpPanel.panel.actor);
+
         this._signalsHandler.add(
             [
                 this.dtpPanel.panel.actor,
@@ -351,6 +354,8 @@ var taskbar = Utils.defineClass({
     },
 
     destroy: function() {
+        this.iconAnimator.destroy();
+
         this._signalsHandler.destroy();
         this._signalsHandler = 0;
 
@@ -549,7 +554,8 @@ var taskbar = Utils.defineClass({
                 showLabel: false,
                 isDraggable: !Me.settings.get_boolean('taskbar-locked'),
             },
-            this.previewMenu
+            this.previewMenu,
+            this.iconAnimator
         );
 
         if (appIcon._draggable) {


### PR DESCRIPTION
When an app icon is marked as "urgent" (using the [Unity Launcher API](https://wiki.ubuntu.com/Unity/LauncherAPI)), this code animates the icon until the app is focused/clicked on again in order to draw attention to it.

Some apps that set the "urgent" property include the Software Updater in Ubuntu (when the system needs to restart after an update) and [Teatime](https://snapcraft.io/teatime) (after the timer rings) like in this clip: https://i.imgur.com/hJewEcj.mp4

(Code adapted from the Dash to Dock extension)