### PR TITLE
Fix offset when gnome-shell top panel is shown

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -861,10 +861,12 @@ var dtpPanel = Utils.defineClass({
         }
 
         if (this.checkIfVertical()) {
+            let viewHeight = this.monitor.height - gsTopPanelOffset;
+            
             if (anchor === Pos.MIDDLE) {
-                anchorPlaceOnMonitor = (this.monitor.height - h) / 2;
+                anchorPlaceOnMonitor = (viewHeight - h) / 2;
             } else if (anchor === Pos.END) {
-                anchorPlaceOnMonitor = this.monitor.height - h;
+                anchorPlaceOnMonitor = viewHeight - h;
             } else { // Pos.START
                 anchorPlaceOnMonitor = 0;
             }


### PR DESCRIPTION
Hello!

After updating to the latest version of the extension I noticed that there was a strange gap between the top gs-panel and the extension's panel. 

Looking through the code I found this [line](https://github.com/home-sweet-gnome/dash-to-panel/blob/6a76c9e9145aa0e28994721421a15dabe37b2be2/panel.js#L865),
```js
anchorPlaceOnMonitor = (this.monitor.height - h) / 2;
```
which I assume is equivalent to,
```js
offset = (fullHeight - panelHeight) / 2
```
However, when the gnome-shell's top-panel is present, `fullHeight` i.e. the full available height is actually less than `this.monitor.height`, which is possibly why the offset is a bit off.

In this PR I added the `gsTopPanelOffset` as part of the calculation, which should hopefully resolve the issue. 
I can confirm that the fix is working for me. :smile: 

### Current Behavior on `master`
![image](https://user-images.githubusercontent.com/10696373/117347891-6a4da680-aecb-11eb-8c40-8e1c63c02283.png)


### After applying the changes in the PR
![image](https://user-images.githubusercontent.com/10696373/117347784-45f1ca00-aecb-11eb-8395-b7ee87783b8c.png)

<hr />

On a side note, a workaround would have been to set the anchor to "TOP" in the preferences, but unfortunately that option isn't available for a full-height panel.
