### PR TITLE
Format value callbacks, app icon animation options dialog layout

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -6,247 +6,242 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="orientation">vertical</property>
+    <property name="hexpand">1</property>
+    <property name="vexpand">1</property>
     <child>
-      <object class="GtkListBox" id="animate_appicon_hover_options_listbox">
+      <object class="GtkListBoxRow" id="animate_appicon_hover_options_type_listboxrow">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="selection_mode">none</property>
+        <property name="can_focus">True</property>
+        <property name="activatable">False</property>
         <child>
-          <object class="GtkListBoxRow" id="animate_appicon_hover_options_type_listboxrow">
+          <object class="GtkBox" id="animate_appicon_hover_options_type_box">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="activatable">False</property>
+            <property name="can_focus">False</property>
+            <property name="margin_start">12</property>
+            <property name="margin_end">12</property>
+            <property name="margin_top">12</property>
+            <property name="margin_bottom">12</property>
+            <property name="spacing">32</property>
             <child>
-              <object class="GtkBox" id="animate_appicon_hover_options_type_box">
+              <object class="GtkLabel" id="animate_appicon_hover_options_type_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_start">12</property>
-                <property name="margin_end">12</property>
-                <property name="margin_top">12</property>
-                <property name="margin_bottom">12</property>
-                <property name="spacing">32</property>
-                <child>
-                  <object class="GtkLabel" id="animate_appicon_hover_options_type_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">Animation type</property>
-                    <property name="xalign">0</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkComboBoxText" id="animate_appicon_hover_options_type_combo">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="valign">center</property>
-                    <items>
-                      <item id="SIMPLE" translatable="yes">Simple</item>
-                      <item id="RIPPLE" translatable="yes">Ripple</item>
-                      <item id="PLANK" translatable="yes">Plank</item>
-                    </items>
-                  </object>
-                </child>
+                <property name="hexpand">True</property>
+                <property name="label" translatable="yes">Animation type</property>
+                <property name="xalign">0</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkComboBoxText" id="animate_appicon_hover_options_type_combo">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">center</property>
+                <items>
+                  <item id="SIMPLE" translatable="yes">Simple</item>
+                  <item id="RIPPLE" translatable="yes">Ripple</item>
+                  <item id="PLANK" translatable="yes">Plank</item>
+                </items>
               </object>
             </child>
           </object>
         </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkListBoxRow" id="animate_appicon_hover_options_params_listboxrow">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="activatable">False</property>
         <child>
-          <object class="GtkListBoxRow" id="animate_appicon_hover_options_params_listboxrow">
+          <object class="GtkGrid" id="animate_appicon_hover_options_params_grid">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="activatable">False</property>
+            <property name="can_focus">False</property>
+            <property name="margin_start">12</property>
+            <property name="margin_end">12</property>
+            <property name="margin_top">12</property>
+            <property name="margin_bottom">12</property>
+            <property name="row_spacing">24</property>
+            <property name="column_spacing">32</property>
             <child>
-              <object class="GtkGrid" id="animate_appicon_hover_options_params_grid">
+              <object class="GtkLabel" id="animate_appicon_hover_options_duration_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_start">12</property>
                 <property name="margin_end">12</property>
-                <property name="margin_top">12</property>
-                <property name="margin_bottom">12</property>
-                <property name="row_spacing">24</property>
-                <property name="column_spacing">32</property>
-                <child>
-                  <object class="GtkLabel" id="animate_appicon_hover_options_duration_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_end">12</property>
-                    <property name="label" translatable="yes">Duration</property>
-                    <property name="use_markup">True</property>
-                    <property name="xalign">0</property>
-                    <property name="valign">end</property>
-                    <layout>
-                      <property name="row">0</property>
-                      <property name="column">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkScale" id="animate_appicon_hover_options_duration_scale">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="valign">end</property>
-                    <property name="hexpand">True</property>
-                    <property name="adjustment">animate_appicon_hover_options_duration_adjustment</property>
-                    <property name="round_digits">0</property>
-                    <property name="digits">0</property>
-                    <property name="value_pos">right</property>
-                    <property name="draw_value">True</property>
-                    <layout>
-                      <property name="row">0</property>
-                      <property name="column">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="animate_appicon_hover_options_extent_rotation">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Rotation</property>
-                    <property name="xalign">0</property>
-                    <property name="valign">end</property>
-                    <layout>
-                      <property name="row">1</property>
-                      <property name="column">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkScale" id="animate_appicon_hover_options_rotation_scale">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="valign">end</property>
-                    <property name="hexpand">True</property>
-                    <property name="adjustment">animate_appicon_hover_options_rotation_adjustment</property>
-                    <property name="round_digits">0</property>
-                    <property name="digits">0</property>
-                    <property name="value_pos">right</property>
-                    <property name="draw_value">True</property>
-                    <layout>
-                      <property name="row">1</property>
-                      <property name="column">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="animate_appicon_hover_options_travel_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Travel</property>
-                    <property name="xalign">0</property>
-                    <property name="valign">end</property>
-                    <layout>
-                      <property name="row">2</property>
-                      <property name="column">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkScale" id="animate_appicon_hover_options_travel_scale">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="valign">end</property>
-                    <property name="hexpand">True</property>
-                    <property name="adjustment">animate_appicon_hover_options_travel_adjustment</property>
-                    <property name="round_digits">0</property>
-                    <property name="digits">0</property>
-                    <property name="value_pos">right</property>
-                    <property name="draw_value">True</property>
-                    <layout>
-                      <property name="row">2</property>
-                      <property name="column">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="animate_appicon_hover_options_zoom_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Zoom</property>
-                    <property name="xalign">0</property>
-                    <property name="valign">end</property>
-                    <layout>
-                      <property name="row">3</property>
-                      <property name="column">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkScale" id="animate_appicon_hover_options_zoom_scale">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="valign">end</property>
-                    <property name="hexpand">True</property>
-                    <property name="adjustment">animate_appicon_hover_options_zoom_adjustment</property>
-                    <property name="round_digits">0</property>
-                    <property name="digits">0</property>
-                    <property name="value_pos">right</property>
-                    <property name="draw_value">True</property>
-                    <layout>
-                      <property name="row">3</property>
-                      <property name="column">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="animate_appicon_hover_options_convexity_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Convexity</property>
-                    <property name="xalign">0</property>
-                    <property name="valign">end</property>
-                    <layout>
-                      <property name="row">4</property>
-                      <property name="column">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkScale" id="animate_appicon_hover_options_convexity_scale">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="valign">end</property>
-                    <property name="hexpand">True</property>
-                    <property name="adjustment">animate_appicon_hover_options_convexity_adjustment</property>
-                    <property name="round_digits">1</property>
-                    <property name="digits">1</property>
-                    <property name="value_pos">right</property>
-                    <property name="draw_value">True</property>
-                    <layout>
-                      <property name="row">4</property>
-                      <property name="column">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="animate_appicon_hover_options_extent_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Extent</property>
-                    <property name="xalign">0</property>
-                    <property name="valign">end</property>
-                    <layout>
-                      <property name="row">0</property>
-                      <property name="column">5</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkScale" id="animate_appicon_hover_options_extent_scale">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="valign">end</property>
-                    <property name="hexpand">True</property>
-                    <property name="adjustment">animate_appicon_hover_options_extent_adjustment</property>
-                    <property name="round_digits">0</property>
-                    <property name="digits">0</property>
-                    <property name="value_pos">right</property>
-                    <property name="draw_value">True</property>
-                    <layout>
-                      <property name="row">5</property>
-                      <property name="column">1</property>
-                    </layout>
-                  </object>
-                </child>
+                <property name="label" translatable="yes">Duration</property>
+                <property name="use_markup">True</property>
+                <property name="xalign">0</property>
+                <property name="valign">end</property>
+                <layout>
+                  <property name="row">0</property>
+                  <property name="column">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScale" id="animate_appicon_hover_options_duration_scale">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="valign">end</property>
+                <property name="hexpand">True</property>
+                <property name="adjustment">animate_appicon_hover_options_duration_adjustment</property>
+                <property name="round_digits">0</property>
+                <property name="digits">0</property>
+                <property name="value_pos">right</property>
+                <property name="draw_value">True</property>
+                <layout>
+                  <property name="row">0</property>
+                  <property name="column">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="animate_appicon_hover_options_extent_rotation">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Rotation</property>
+                <property name="xalign">0</property>
+                <property name="valign">end</property>
+                <layout>
+                  <property name="row">1</property>
+                  <property name="column">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScale" id="animate_appicon_hover_options_rotation_scale">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="valign">end</property>
+                <property name="hexpand">True</property>
+                <property name="adjustment">animate_appicon_hover_options_rotation_adjustment</property>
+                <property name="round_digits">0</property>
+                <property name="digits">0</property>
+                <property name="value_pos">right</property>
+                <property name="draw_value">True</property>
+                <layout>
+                  <property name="row">1</property>
+                  <property name="column">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="animate_appicon_hover_options_travel_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Travel</property>
+                <property name="xalign">0</property>
+                <property name="valign">end</property>
+                <layout>
+                  <property name="row">2</property>
+                  <property name="column">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScale" id="animate_appicon_hover_options_travel_scale">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="valign">end</property>
+                <property name="hexpand">True</property>
+                <property name="adjustment">animate_appicon_hover_options_travel_adjustment</property>
+                <property name="round_digits">0</property>
+                <property name="digits">0</property>
+                <property name="value_pos">right</property>
+                <property name="draw_value">True</property>
+                <layout>
+                  <property name="row">2</property>
+                  <property name="column">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="animate_appicon_hover_options_zoom_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Zoom</property>
+                <property name="xalign">0</property>
+                <property name="valign">end</property>
+                <layout>
+                  <property name="row">3</property>
+                  <property name="column">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScale" id="animate_appicon_hover_options_zoom_scale">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="valign">end</property>
+                <property name="hexpand">True</property>
+                <property name="adjustment">animate_appicon_hover_options_zoom_adjustment</property>
+                <property name="round_digits">0</property>
+                <property name="digits">0</property>
+                <property name="value_pos">right</property>
+                <property name="draw_value">True</property>
+                <layout>
+                  <property name="row">3</property>
+                  <property name="column">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="animate_appicon_hover_options_convexity_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Convexity</property>
+                <property name="xalign">0</property>
+                <property name="valign">end</property>
+                <layout>
+                  <property name="row">4</property>
+                  <property name="column">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScale" id="animate_appicon_hover_options_convexity_scale">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="valign">end</property>
+                <property name="hexpand">True</property>
+                <property name="adjustment">animate_appicon_hover_options_convexity_adjustment</property>
+                <property name="round_digits">1</property>
+                <property name="digits">1</property>
+                <property name="value_pos">right</property>
+                <property name="draw_value">True</property>
+                <layout>
+                  <property name="row">4</property>
+                  <property name="column">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="animate_appicon_hover_options_extent_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Extent</property>
+                <property name="xalign">0</property>
+                <property name="valign">end</property>
+                <layout>
+                  <property name="row">5</property>
+                  <property name="column">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScale" id="animate_appicon_hover_options_extent_scale">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="valign">end</property>
+                <property name="hexpand">True</property>
+                <property name="adjustment">animate_appicon_hover_options_extent_adjustment</property>
+                <property name="round_digits">0</property>
+                <property name="digits">0</property>
+                <property name="value_pos">right</property>
+                <property name="draw_value">True</property>
+                <layout>
+                  <property name="row">5</property>
+                  <property name="column">1</property>
+                </layout>
               </object>
             </child>
           </object>

--- a/Settings.ui
+++ b/Settings.ui
@@ -90,7 +90,7 @@
                     <property name="round_digits">0</property>
                     <property name="digits">0</property>
                     <property name="value_pos">right</property>
-                    <!-- <signal name="format-value" handler="animate_appicon_hover_options_duration_scale_format_value_cb" swapped="no"/> -->
+                    <property name="draw_value">True</property>
                     <layout>
                       <property name="row">0</property>
                       <property name="column">1</property>
@@ -120,7 +120,7 @@
                     <property name="round_digits">0</property>
                     <property name="digits">0</property>
                     <property name="value_pos">right</property>
-                    <!-- <signal name="format-value" handler="animate_appicon_hover_options_rotation_scale_format_value_cb" swapped="no"/> -->
+                    <property name="draw_value">True</property>
                     <layout>
                       <property name="row">1</property>
                       <property name="column">1</property>
@@ -150,7 +150,7 @@
                     <property name="round_digits">0</property>
                     <property name="digits">0</property>
                     <property name="value_pos">right</property>
-                    <!-- <signal name="format-value" handler="animate_appicon_hover_options_travel_scale_format_value_cb" swapped="no"/> -->
+                    <property name="draw_value">True</property>
                     <layout>
                       <property name="row">2</property>
                       <property name="column">1</property>
@@ -180,7 +180,7 @@
                     <property name="round_digits">0</property>
                     <property name="digits">0</property>
                     <property name="value_pos">right</property>
-                    <!-- <signal name="format-value" handler="animate_appicon_hover_options_zoom_scale_format_value_cb" swapped="no"/> -->
+                    <property name="draw_value">True</property>
                     <layout>
                       <property name="row">3</property>
                       <property name="column">1</property>
@@ -210,7 +210,7 @@
                     <property name="round_digits">1</property>
                     <property name="digits">1</property>
                     <property name="value_pos">right</property>
-                    <!-- <signal name="format-value" handler="animate_appicon_hover_options_convexity_scale_format_value_cb" swapped="no"/> -->
+                    <property name="draw_value">True</property>
                     <layout>
                       <property name="row">4</property>
                       <property name="column">1</property>
@@ -240,7 +240,7 @@
                     <property name="round_digits">0</property>
                     <property name="digits">0</property>
                     <property name="value_pos">right</property>
-                    <!-- <signal name="format-value" handler="animate_appicon_hover_options_extent_scale_format_value_cb" swapped="no"/> -->
+                    <property name="draw_value">True</property>
                     <layout>
                       <property name="row">5</property>
                       <property name="column">1</property>
@@ -4858,7 +4858,7 @@
                                             <property name="round_digits">0</property>
                                             <property name="digits">0</property>
                                             <property name="value_pos">right</property>
-                                            <!-- <signal name="format-value" handler="panel_size_scale_format_value_cb" swapped="no"/> -->
+                                            <property name="draw_value">True</property>
                                             <signal name="value-changed" handler="panel_size_scale_value_changed_cb" swapped="no"/>
                                             <layout>
                                               <property name="row">1</property>
@@ -4900,6 +4900,7 @@
                                             <property name="round_digits">0</property>
                                             <property name="digits">0</property>
                                             <property name="value_pos">right</property>
+                                            <property name="draw_value">True</property>
                                             <layout>
                                               <property name="row">2</property>
                                               <property name="column">1</property>
@@ -5116,6 +5117,7 @@
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
+                                <property name="draw_value">True</property>
                                 <signal name="value-changed" handler="appicon_margin_scale_value_changed_cb" swapped="no"/>
                                 <layout>
                                   <property name="row">0</property>
@@ -5163,6 +5165,7 @@
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
+                                <property name="draw_value">True</property>
                                 <signal name="value-changed" handler="appicon_padding_scale_value_changed_cb" swapped="no"/>
                                 <layout>
                                   <property name="row">0</property>
@@ -6850,6 +6853,7 @@
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
+                                <property name="draw_value">True</property>
                                 <signal name="value-changed" handler="tray_size_scale_value_changed_cb" swapped="no"/>
                                 <layout>
                                   <property name="row">0</property>
@@ -6879,6 +6883,7 @@
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
+                                <property name="draw_value">True</property>
                                 <signal name="value-changed" handler="leftbox_size_scale_value_changed_cb" swapped="no"/>
                                 <layout>
                                   <property name="row">1</property>
@@ -6944,6 +6949,7 @@
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
+                                <property name="draw_value">True</property>
                                 <signal name="value-changed" handler="tray_padding_scale_value_changed_cb" swapped="no"/>
                                 <layout>
                                   <property name="row">0</property>
@@ -6973,6 +6979,7 @@
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
+                                <property name="draw_value">True</property>
                                 <signal name="value-changed" handler="statusicon_padding_scale_value_changed_cb" swapped="no"/>
                                 <layout>
                                   <property name="row">1</property>
@@ -7002,6 +7009,7 @@
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
+                                <property name="draw_value">True</property>
                                 <signal name="value-changed" handler="leftbox_padding_scale_value_changed_cb" swapped="no"/>
                                 <layout>
                                   <property name="row">2</property>

--- a/prefs.js
+++ b/prefs.js
@@ -181,6 +181,7 @@ const Preferences = new Lang.Class({
         this._tray_padding_timeout = 0;
         this._statusicon_padding_timeout = 0;
         this._leftbox_padding_timeout = 0;
+        this._addFormatValueCallbacks();
         this._bindSettings();
     },
 
@@ -551,6 +552,83 @@ const Preferences = new Lang.Class({
 
         dialog.show();
         dialog.set_default_size(1, 1);
+    },
+
+    _addFormatValueCallbacks: function() {
+        // position
+        this._builder.get_object('panel_size_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return value + ' px';
+        }));
+
+        // style
+        this._builder.get_object('appicon_margin_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return value + ' px';
+        }));
+
+        this._builder.get_object('appicon_padding_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return value + ' px';
+        }));
+
+        // fine-tune box1
+        this._builder.get_object('tray_size_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return value + ' px';
+        }));
+
+        this._builder.get_object('leftbox_size_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return value + ' px';
+        }));
+
+        // fine-tune box2
+        this._builder.get_object('tray_padding_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return value + ' px';
+        }));
+
+        this._builder.get_object('statusicon_padding_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return value + ' px';
+        }));
+
+        this._builder.get_object('leftbox_padding_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return value + ' px';
+        }));
+
+        // animate hovering app icons dialog
+        this._builder.get_object('animate_appicon_hover_options_duration_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return _("%d ms").format(value);
+        }));
+
+        this._builder.get_object('animate_appicon_hover_options_rotation_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return _("%d °").format(value);
+        }));
+
+        this._builder.get_object('animate_appicon_hover_options_travel_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return _("%d %%").format(value);
+        }));
+
+        this._builder.get_object('animate_appicon_hover_options_zoom_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return _("%d %%").format(value);
+        }));
+
+        this._builder.get_object('animate_appicon_hover_options_convexity_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return _("%.1f").format(value);
+        }));
+
+        this._builder.get_object('animate_appicon_hover_options_extent_scale')
+        .set_format_value_func(Lang.bind(this, function(scale, value) {
+            return Gettext.ngettext("%d icon", "%d icons", value).format(value);
+        }));
     },
 
     _bindSettings: function() {
@@ -2065,7 +2143,7 @@ const Preferences = new Lang.Class({
 
         this._builder.get_object('animate_appicon_hover_button').connect('clicked', Lang.bind(this, function() {
             let dialog = new Gtk.Dialog({ title: _('App icon animation options'),
-                                          transient_for: this.widget.get_toplevel(),
+                                          transient_for: this.notebook.get_root(),
                                           use_header_bar: true,
                                           modal: true });
 
@@ -2074,7 +2152,7 @@ const Preferences = new Lang.Class({
             dialog.add_button(_('Reset to defaults'), 1);
 
             let box = this._builder.get_object('animate_appicon_hover_options');
-            dialog.get_content_area().add(box);
+            dialog.get_content_area().append(box);
 
             dialog.connect('response', Lang.bind(this, function(dialog, id) {
                 if (id == 1) {
@@ -2094,7 +2172,7 @@ const Preferences = new Lang.Class({
                 return;
             }));
 
-            dialog.show_all();
+            dialog.show();
 
         }));
 
@@ -2228,30 +2306,6 @@ const BuilderScope = GObject.registerClass({
         connectObject.set_label("Clicked");
     }
 
-    animate_appicon_hover_options_duration_scale_format_value_cb(scale, value) {
-        return _("%d ms").format(value);
-    }
-
-    animate_appicon_hover_options_rotation_scale_format_value_cb(scale, value) {
-        return _("%d °").format(value);
-    }
-
-    animate_appicon_hover_options_travel_scale_format_value_cb(scale, value) {
-        return _("%d %%").format(value);
-    }
-
-    animate_appicon_hover_options_zoom_scale_format_value_cb(scale, value) {
-        return _("%d %%").format(value);
-    }
-
-    animate_appicon_hover_options_convexity_scale_format_value_cb(scale, value) {
-        return _("%.1f").format(value);
-    }
-
-    animate_appicon_hover_options_extent_scale_format_value_cb(scale, value) {
-        return Gettext.ngettext("%d icon", "%d icons", value).format(value);
-    }
-
     position_bottom_button_clicked_cb(button) {
         if (!this._preferences._ignorePositionRadios && button.get_active()) this._preferences._setPanelPosition(Pos.BOTTOM);
     }
@@ -2298,10 +2352,6 @@ const BuilderScope = GObject.registerClass({
             this._preferences._settings.set_string('window-preview-title-position', 'TOP');
     }
 
-    panel_size_scale_format_value_cb(scale, value) {
-        return value+ ' px';
-    }
-
     panel_size_scale_value_changed_cb(scale) {
         // Avoid settings the size consinuosly
         if (this._preferences._panel_size_timeout > 0)
@@ -2312,10 +2362,6 @@ const BuilderScope = GObject.registerClass({
             this._preferences._panel_size_timeout = 0;
             return GLib.SOURCE_REMOVE;
         }));
-    }
-
-    tray_size_scale_format_value_cb(scale, value) {
-        return value+ ' px';
     }
 
     tray_size_scale_value_changed_cb(scale) {
@@ -2330,10 +2376,6 @@ const BuilderScope = GObject.registerClass({
         }));
     }
 
-    leftbox_size_scale_format_value_cb(scale, value) {
-        return value+ ' px';
-    }
-
     leftbox_size_scale_value_changed_cb(scale) {
         // Avoid settings the size consinuosly
         if (this._preferences._leftbox_size_timeout > 0)
@@ -2344,10 +2386,6 @@ const BuilderScope = GObject.registerClass({
             this._preferences._leftbox_size_timeout = 0;
             return GLib.SOURCE_REMOVE;
         }));
-    }
-
-    appicon_margin_scale_format_value_cb(scale, value) {
-        return value+ ' px';
     }
 
     appicon_margin_scale_value_changed_cb(scale) {
@@ -2362,10 +2400,6 @@ const BuilderScope = GObject.registerClass({
         }));
     }
 
-    appicon_padding_scale_format_value_cb(scale, value) {
-        return value + ' px';
-    }
-
     appicon_padding_scale_value_changed_cb(scale) {
         // Avoid settings the size consinuosly
         if (this._preferences._appicon_padding_timeout > 0)
@@ -2376,10 +2410,6 @@ const BuilderScope = GObject.registerClass({
             this._preferences._appicon_padding_timeout = 0;
             return GLib.SOURCE_REMOVE;
         }));
-    }
-
-    tray_padding_scale_format_value_cb(scale, value) {
-        return value+ ' px';
     }
 
     tray_padding_scale_value_changed_cb(scale) {
@@ -2394,10 +2424,6 @@ const BuilderScope = GObject.registerClass({
         }));
     }
 
-    statusicon_padding_scale_format_value_cb(scale, value) {
-        return value+ ' px';
-    }
-
     statusicon_padding_scale_value_changed_cb(scale) {
         // Avoid settings the size consinuosly
         if (this._preferences._statusicon_padding_timeout > 0)
@@ -2408,10 +2434,6 @@ const BuilderScope = GObject.registerClass({
             this._preferences._statusicon_padding_timeout = 0;
             return GLib.SOURCE_REMOVE;
         }));
-    }
-
-    leftbox_padding_scale_format_value_cb(scale, value) {
-        return value+ ' px';
     }
 
     leftbox_padding_scale_value_changed_cb(scale) {


### PR DESCRIPTION
- format-value callback for GtkScale can no longer be set via .ui file, so set the callbacks directly in the prefs.js via set_format_value_func.
- also fixed app icon animation options dialog layout