### PR TITLE
Fix transparency issue after overview has been shown and hidden

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -44,11 +44,6 @@ let extensionSystem = (Main.extensionManager || imports.ui.extensionSystem);
 
 function init() {
     this._realHasOverview = Main.sessionMode.hasOverview;
-    Main.overview._hideDoneClone = Main.overview._hideDone;
-    Main.overview._hideDone = function() {
-        Main.overview._hideDoneClone();
-        Main.loadTheme();
-    };
 
     Convenience.initTranslations(Utils.TRANSLATION_DOMAIN);
     
@@ -149,5 +144,4 @@ function disable(reset) {
     }
 
     Main.sessionMode.hasOverview = this._realHasOverview;
-    Main.overview._hideDone = Main.overview._hideDoneClone;
 }

--- a/extension.js
+++ b/extension.js
@@ -44,6 +44,11 @@ let extensionSystem = (Main.extensionManager || imports.ui.extensionSystem);
 
 function init() {
     this._realHasOverview = Main.sessionMode.hasOverview;
+    Main.overview._hideDoneClone = Main.overview._hideDone;
+    Main.overview._hideDone = function() {
+        Main.overview._hideDoneClone();
+        Main.loadTheme();
+    };
 
     Convenience.initTranslations(Utils.TRANSLATION_DOMAIN);
     
@@ -144,4 +149,5 @@ function disable(reset) {
     }
 
     Main.sessionMode.hasOverview = this._realHasOverview;
+    Main.overview._hideDone = Main.overview._hideDoneClone;
 }

--- a/panel.js
+++ b/panel.js
@@ -103,7 +103,7 @@ var dtpPanel = Utils.defineClass({
 
         let position = this.getPosition();
 
-        if (isStandalone) {
+        if (true) { // force the isStandalone path, transparency will work, but lots of others stuff breaks
             this.panel = new dtpSecondaryPanel({ name: 'panel', reactive: true });
             this.statusArea = this.panel.statusArea = {};
 


### PR DESCRIPTION
This is a workaround / potential fix for the transparency issue after exit overview.