### PR TITLE
Fix panel disappearing after screen unlock with fullscreen content

### DIFF
--- a/panelManager.js
+++ b/panelManager.js
@@ -398,7 +398,10 @@ var dtpPanelManager = Utils.defineClass({
         panelBox.add(panel);
         panel.enable();
 
-        panelBox.visible = !monitor.inFullscreen;
+        panelBox.visible = true;
+        if (monitor.inFullscreen) {
+            panelBox.hide();
+        }
         panelBox.set_position(0, 0);
 
         return panel;


### PR DESCRIPTION
Fixed a bug that caused the panel to disappear after locking the screen while fullscreen content is playing  (#1236).

It appears that setting the panelBox visibility to be false if fullscreen content is on top while creating the panel (when unlocking the screen in this case) is stopping the panel from initialising fully.

If we always set the panel to be visible but hide it immediately afterwards if fullscreen content is on top, we fix this issue while keeping the expected behaviour (i.e. not drawing the panel on top of fullscreen content).

I have tested that this fix works in Gnome Shell 3.38.4 and Gnome 40