### PR TITLE
Make the preferences dialog resizable

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -168,7 +168,6 @@ const Preferences = new Lang.Class({
         this._builder.set_translation_domain(Me.metadata['gettext-domain']);
         this._builder.add_from_file(Me.path + '/Settings.ui');
         this.notebook = this._builder.get_object('settings_notebook');
-        this.notebook.set_size_request(680, 740);
 
         // Timeout to delay the update of the settings
         this._panel_size_timeout = 0;
@@ -2460,6 +2459,8 @@ function init() {
 }
 
 function buildPrefsWidget() {
+    Gtk.Window.list_toplevels()[0].set_default_size(680, 740);
+    
     let preferences = new Preferences();
     
     return preferences.notebook;


### PR DESCRIPTION
Size the toplevel dialog instead of the notebook.