### PR TITLE
destroy show apps file chooser dialog when show apps dialog is closed

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -492,6 +492,7 @@ const Preferences = new Lang.Class({
                 // remove the settings box so it doesn't get destroyed;
                 dialog.get_content_area().remove(box);
                 dialog.destroy();
+                fileChooser.destroy();
             }
             return;
         }));


### PR DESCRIPTION
The "Show Applications options" dialog creates a new file chooser every time it is opened. But it is not destroyed, so the file chooser instances multiply. This is fixed by this PR.