### PR TITLE
Use .get_names() only on Gio.ThemedIcon instances

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -843,11 +843,13 @@ var DominantColorExtractor = defineClass({
         }
 
         // Get the pixel buffer from the icon theme
-        let icon_info = themeLoader.lookup_icon(iconTexture.get_names()[0], DOMINANT_COLOR_ICON_SIZE, 0);
-        if (icon_info !== null)
-            return icon_info.load_icon();
-        else
-            return null;
+        if (iconTexture instanceof Gio.ThemedIcon) {
+            let icon_info = themeLoader.lookup_icon(iconTexture.get_names()[0], DOMINANT_COLOR_ICON_SIZE, 0);
+            if (icon_info !== null)
+                return icon_info.load_icon();
+        }
+
+        return null;
     },
 
     /**


### PR DESCRIPTION
The `.get_names()` method only exists for `Gio.ThemedIcon` instances. This avoids spamming the journal with errors like the following:

```
JS ERROR: TypeError: iconTexture.get_names is not a function
_getIconPixBuf@/home/aperez/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/utils.js:846:61
_getColorPalette@/home/aperez/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/utils.js:865:27
_getFocusHighlightColor@/home/aperez/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/appIcons.js:1089:31
_setIconStyle@/home/aperez/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/appIcons.js:606:39
_displayProperIndicator@/home/aperez/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/appIcons.js:703:14
_onSwitchWorkspace/<@/home/aperez/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/appIcons.js:692:58
_create/this[name]<@/home/aperez/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/utils.js:250:13
```