### PR TITLE
Fix makefile POT file generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,10 @@ mergepo: potfile
 
 ./po/dash-to-panel.pot: $(TOLOCALIZE) Settings.ui
 	mkdir -p po
-	xgettext -k_ -kN_ -o po/dash-to-panel.pot --package-name "Dash To Panel" $(TOLOCALIZE)
+	xgettext -k_ -kN_ -o po/dash-to-panel.pot --package-name "Dash To Panel" $(TOLOCALIZE) --from-code=UTF-8
 	intltool-extract --type=gettext/glade Settings.ui
 	xgettext -k_ -kN_ --join-existing -o po/dash-to-panel.pot Settings.ui.h
+	sed -i -e 's/&\#10;/\\n/g' po/dash-to-panel.pot
 
 ./po/%.mo: ./po/%.po
 	msgfmt -c $< -o $@


### PR DESCRIPTION
Resolve #1415 
 - generate POT file with non asci symbols (use UTF-8)
 - change newline symbol in POT file (by sed)