### PR TITLE
Use startInOverview flag to hide overview on startup (Ubuntu only atm)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -92,6 +92,8 @@ function _enable() {
     Me.settings = Convenience.getSettings('org.gnome.shell.extensions.dash-to-panel');
     Me.desktopSettings = Convenience.getSettings('org.gnome.desktop.interface');
 
+    Main.layoutManager.startInOverview = !Me.settings.get_boolean('hide-overview-on-startup');
+
     if (Me.settings.get_boolean('hide-overview-on-startup') && Main.layoutManager._startingUp) {
         Main.sessionMode.hasOverview = false;
         Main.layoutManager.connect('startup-complete', () => {


### PR DESCRIPTION
Use startInOverview flag, so hide overview will work in Ubuntu again.
The flag was added https://salsa.debian.org/gnome-team/gnome-shell/-/merge_requests/52 for Ubuntu.