### PR TITLE
Gnome 41 compatibility

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -91,7 +91,7 @@ let recentlyClickedAppIndex = 0;
 let recentlyClickedAppMonitorIndex;
 
 let tracker = Shell.WindowTracker.get_default();
-let menuRedisplayFunc = !!AppDisplay.AppMenu.prototype._rebuildMenu ? '_rebuildMenu' : '_redisplay';
+let menuRedisplayFunc = !!(AppDisplay.AppMenu || AppDisplay.AppIconMenu).prototype._rebuildMenu ? '_rebuildMenu' : '_redisplay';
 
 /**
  * Extend AppIcon
@@ -1452,7 +1452,7 @@ function getIconPadding(monitorIndex) {
 }
 
 /**
- * Extend AppMenu
+ * Extend AppMenu (AppIconMenu for pre gnome 41)
  *
  * - set popup arrow side based on taskbar orientation
  * - Add close windows option based on quitfromdash extension
@@ -1461,7 +1461,7 @@ function getIconPadding(monitorIndex) {
 
 var taskbarSecondaryMenu = Utils.defineClass({
     Name: 'DashToPanel.SecondaryMenu',
-    Extends: AppDisplay.AppMenu,
+    Extends: (AppDisplay.AppMenu || AppDisplay.AppIconMenu),
     ParentConstrParams: [[0]],
 
     _init: function(source, panel) {

--- a/appIcons.js
+++ b/appIcons.js
@@ -91,7 +91,7 @@ let recentlyClickedAppIndex = 0;
 let recentlyClickedAppMonitorIndex;
 
 let tracker = Shell.WindowTracker.get_default();
-let menuRedisplayFunc = !!AppDisplay.AppIconMenu.prototype._rebuildMenu ? '_rebuildMenu' : '_redisplay';
+let menuRedisplayFunc = !!AppDisplay.AppMenu.prototype._rebuildMenu ? '_rebuildMenu' : '_redisplay';
 
 /**
  * Extend AppIcon
@@ -1452,7 +1452,7 @@ function getIconPadding(monitorIndex) {
 }
 
 /**
- * Extend AppIconMenu
+ * Extend AppMenu
  *
  * - set popup arrow side based on taskbar orientation
  * - Add close windows option based on quitfromdash extension
@@ -1461,7 +1461,7 @@ function getIconPadding(monitorIndex) {
 
 var taskbarSecondaryMenu = Utils.defineClass({
     Name: 'DashToPanel.SecondaryMenu',
-    Extends: AppDisplay.AppIconMenu,
+    Extends: AppDisplay.AppMenu,
     ParentConstrParams: [[0]],
 
     _init: function(source, panel) {

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
 "uuid": "dash-to-panel@jderose9.github.com",
 "name": "Dash to Panel",
 "description": "An icon taskbar for the Gnome Shell. This extension moves the dash into the gnome main panel so that the application launchers and system tray are combined into a single panel, similar to that found in KDE Plasma and Windows 7+. A separate dock is no longer needed for easy access to running and favorited applications.\n\nFor a more traditional experience, you may also want to use Tweak Tool to enable Windows > Titlebar Buttons > Minimize & Maximize.\n\nFor the best support, please report any issues on Github. Dash-to-panel is developed and maintained by @jderose9 and @charlesg99.",
-"shell-version": [ "40" ],
+"shell-version": [ "40", "41" ],
 "url": "https://github.com/jderose9/dash-to-panel",
 "gettext-domain": "dash-to-panel",
 "version": 9999


### PR DESCRIPTION
AppIconMenu got renamed to AppMenu in Gnome 41, with this PR it will work again on gnome 41.