### PR TITLE
Show icons when all window minimized on preview

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -1309,8 +1309,11 @@ var dtpPanel = Utils.defineClass({
 
     _toggleWorkspaceWindows: function(hide, workspace) {
         let time = Me.settings.get_int('show-showdesktop-time') * .001;
-
-        workspace.list_windows().forEach(w => {
+        let current_workspace = Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace();
+        let windows = current_workspace.list_windows().filter(function (w) {
+            return w.showing_on_its_workspace() && !w.skip_taskbar;
+        });
+        windows.forEach(w => {
             if (!w.minimized) {
                 let tweenOpts = {
                     opacity: hide ? 0 : 255,


### PR DESCRIPTION
When hovering over the show desktop button, when reveal desktop is activated, desktop icons from DING are not shown as even that hidden window is minimzed.

This commit follow the same algorithm as clicking on the show desktop button, and the icons on the desktop are still shown and not minimized because the DING window with the desktop icons is hidden from the taskbar.