### PR TITLE
Fix volume control on scroll for Gnome 40+

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -1391,7 +1391,7 @@ var dtpPanel = Utils.defineClass({
                 Utils.activateSiblingWindow(windows, direction);
             } else if (scrollAction === 'CHANGE_VOLUME' && !event.is_pointer_emulated()) {
                 var proto = Volume.Indicator.prototype;
-                var func = proto.vfunc_scroll_event || proto._onScrollEvent;
+                var func = proto._handleScrollEvent || proto.vfunc_scroll_event || proto._onScrollEvent;
     
                 func.call(Main.panel.statusArea.aggregateMenu._volume, 0, event);
             } else {


### PR DESCRIPTION
A change of function name change for the scroll handler caused this issue in this commit:
https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1566/diffs

Fixes #1374 