### PR TITLE
Updated AppMenu, PopupMenu handling for gnome 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
 "uuid": "dash-to-panel@jderose9.github.com",
 "name": "Dash to Panel",
 "description": "An icon taskbar for the Gnome Shell. This extension moves the dash into the gnome main panel so that the application launchers and system tray are combined into a single panel, similar to that found in KDE Plasma and Windows 7+. A separate dock is no longer needed for easy access to running and favorited applications.\n\nFor a more traditional experience, you may also want to use Tweak Tool to enable Windows > Titlebar Buttons > Minimize & Maximize.\n\nFor the best support, please report any issues on Github. Dash-to-panel is developed and maintained by @jderose9 and @charlesg99.",
-"shell-version": [ "40", "41" ],
+"shell-version": [ "41" ],
 "url": "https://github.com/jderose9/dash-to-panel",
 "gettext-domain": "dash-to-panel",
 "version": 9999

--- a/panel.js
+++ b/panel.js
@@ -1066,8 +1066,7 @@ var dtpPanel = Utils.defineClass({
             Main.layoutManager.setDummyCursorGeometry(stageX, stageY, 0, 0);
 
             this.showAppsIconWrapper.createMenu();
-            this.showAppsIconWrapper._menu.sourceActor = Main.layoutManager.dummyCursor;
-            this.showAppsIconWrapper.popupMenu();
+            this.showAppsIconWrapper.popupMenu(Main.layoutManager.dummyCursor);
 
             return Clutter.EVENT_STOP;
         } else if (Main.modalCount > 0 || event.get_source() != actor || 


### PR DESCRIPTION
Fix right click menus on panel + icons in panel (#1488):
- [x] AppMenu if you click on icons in panel
- [x] PopupMenu if you click on panel

Currently these changes break compatibility to gnome 40.