### PR TITLE
CSS Improvements for Vertical Panel

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -74,8 +74,15 @@
 	max-width: 400px;
 }
 
+.dashtopanelMainPanel.vertical .panel-button .popup-menu-arrow {
+	width: 0;
+	height: 0;
+}
+
 .dashtopanelMainPanel.vertical .panel-button {
-	text-align: center; 
+	text-align: center;
+	-natural-hpadding: 0;
+	-minimum-hpadding: 0;
 }
 
 .dashtopanelMainPanel.vertical .panel-button.vertical *,
@@ -87,7 +94,7 @@
 .dashtopanelMainPanel.vertical .panel-button > *,
 .dashtopanelMainPanel.vertical .panel-button.vertical > *,
 .dashtopanelMainPanel.vertical .panel-button.clock-display > * {
-	padding: 8px 0; 
+	padding: 8px 0;
 }
 
 #dashtopanelThumbnailList {


### PR DESCRIPTION
Hide drop down arrows (triangles) and reduce the horizontal padding so buttons/text can use the whole width.