### PR TITLE
Override panel theme background color with dominant icon color

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -5456,6 +5456,56 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkListBoxRow" id="trans_bg_icon_row">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <child>
+                          <object class="GtkGrid" id="trans_bg_icon_grid">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="column_spacing">32</property>
+                            <child>
+                              <object class="GtkLabel" id="trans_bg_icon_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="label" translatable="yes">Override panel theme background color with dominant icon color </property>
+                                <property name="use_markup">True</property>
+                                <property name="xalign">0</property>
+                                <layout>
+                                  <property name="row">0</property>
+                                  <property name="column">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="trans_bg_icon_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                  <object class="GtkSwitch" id="trans_bg_icon_switch">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                  </object>
+                                </child>
+                                <layout>
+                                  <property name="row">0</property>
+                                  <property name="column">1</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkListBoxRow" id="listbox_preview_show_title1">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>

--- a/Settings.ui
+++ b/Settings.ui
@@ -4331,6 +4331,11 @@
     <property name="step_increment">5</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="trans_bg_icon_brightness_adjustment">
+    <property name="upper">100</property>
+    <property name="step_increment">5</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="trans_opacity_min_adjustment">
     <property name="upper">100</property>
     <property name="step_increment">5</property>
@@ -5498,6 +5503,50 @@
                                 <layout>
                                   <property name="row">0</property>
                                   <property name="column">1</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkGrid" id="trans_bg_icon_options_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_start">12</property>
+                                <property name="margin_end">12</property>
+                                <property name="margin_top">12</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="column_spacing">32</property>
+                                <child>
+                                  <object class="GtkLabel" id="trans_bg_icon_brightness_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">Panel dominant color brightness (%)</property>
+                                    <property name="use_markup">True</property>
+                                    <property name="xalign">0</property>
+                                    <layout>
+                                      <property name="row">0</property>
+                                      <property name="column">0</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinButton" id="trans_bg_icon_brightness_spinbutton">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <property name="text" translatable="yes">0</property>
+                                    <property name="adjustment">trans_bg_icon_brightness_adjustment</property>
+                                    <layout>
+                                      <property name="row">0</property>
+                                      <property name="column">1</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <layout>
+                                  <property name="row">1</property>
+                                  <property name="column">0</property>
+                                  <property name="column-span">2</property>
                                 </layout>
                               </object>
                             </child>

--- a/Settings.ui
+++ b/Settings.ui
@@ -4336,6 +4336,11 @@
     <property name="step_increment">5</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="trans_bg_icon_preview_brightness_adjustment">
+    <property name="upper">100</property>
+    <property name="step_increment">5</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="trans_opacity_min_adjustment">
     <property name="upper">100</property>
     <property name="step_increment">5</property>
@@ -5465,49 +5470,12 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <child>
-                          <object class="GtkGrid" id="trans_bg_icon_grid">
+                          <object class="GtkBox" id="trans_bg_icon_main_box">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="margin_start">12</property>
-                            <property name="margin_end">12</property>
-                            <property name="margin_top">12</property>
-                            <property name="margin_bottom">12</property>
-                            <property name="column_spacing">32</property>
+                            <property name="orientation">vertical</property>
                             <child>
-                              <object class="GtkLabel" id="trans_bg_icon_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="hexpand">True</property>
-                                <property name="label" translatable="yes">Override panel theme background color with dominant icon color </property>
-                                <property name="use_markup">True</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="row">0</property>
-                                  <property name="column">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="trans_bg_icon_box">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkSwitch" id="trans_bg_icon_switch">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="halign">end</property>
-                                    <property name="valign">center</property>
-                                  </object>
-                                </child>
-                                <layout>
-                                  <property name="row">0</property>
-                                  <property name="column">1</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkGrid" id="trans_bg_icon_options_box">
+                              <object class="GtkGrid" id="trans_bg_icon_grid">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="margin_start">12</property>
@@ -5516,11 +5484,11 @@
                                 <property name="margin_bottom">12</property>
                                 <property name="column_spacing">32</property>
                                 <child>
-                                  <object class="GtkLabel" id="trans_bg_icon_brightness_label">
+                                  <object class="GtkLabel" id="trans_bg_icon_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="hexpand">True</property>
-                                    <property name="label" translatable="yes">Panel dominant color brightness (%)</property>
+                                    <property name="label" translatable="yes">Override panel theme background color with dominant icon color </property>
                                     <property name="use_markup">True</property>
                                     <property name="xalign">0</property>
                                     <layout>
@@ -5530,24 +5498,120 @@
                                   </object>
                                 </child>
                                 <child>
-                                  <object class="GtkSpinButton" id="trans_bg_icon_brightness_spinbutton">
+                                  <object class="GtkBox" id="trans_bg_icon_box">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="halign">end</property>
-                                    <property name="valign">center</property>
-                                    <property name="text" translatable="yes">0</property>
-                                    <property name="adjustment">trans_bg_icon_brightness_adjustment</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">6</property>
+                                    <child>
+                                      <object class="GtkSwitch" id="trans_bg_icon_switch">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                      </object>
+                                    </child>
                                     <layout>
                                       <property name="row">0</property>
                                       <property name="column">1</property>
                                     </layout>
                                   </object>
                                 </child>
-                                <layout>
-                                  <property name="row">1</property>
-                                  <property name="column">0</property>
-                                  <property name="column-span">2</property>
-                                </layout>
+                                <child>
+                                  <object class="GtkGrid" id="trans_bg_icon_options_box">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_top">12</property>
+                                    <property name="row_spacing">6</property>
+                                    <child>
+                                      <object class="GtkLabel" id="trans_bg_icon_brightness_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="label" translatable="yes">Panel dominant color brightness (%)</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="xalign">0</property>
+                                        <layout>
+                                          <property name="row">0</property>
+                                          <property name="column">0</property>
+                                        </layout>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="trans_bg_icon_brightness_spinbutton">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                        <property name="text" translatable="yes">0</property>
+                                        <property name="adjustment">trans_bg_icon_brightness_adjustment</property>
+                                        <layout>
+                                          <property name="row">0</property>
+                                          <property name="column">1</property>
+                                        </layout>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="trans_bg_icon_preview_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="label" translatable="yes">Apply to window preview</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="xalign">0</property>
+                                        <layout>
+                                          <property name="row">1</property>
+                                          <property name="column">0</property>
+                                        </layout>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSwitch" id="trans_bg_icon_preview_switch">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                        <layout>
+                                          <property name="row">1</property>
+                                          <property name="column">1</property>
+                                        </layout>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="trans_bg_icon_preview_brightness_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="label" translatable="yes">Window preview brightness (%)</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="xalign">0</property>
+                                        <layout>
+                                          <property name="row">2</property>
+                                          <property name="column">0</property>
+                                        </layout>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="trans_bg_icon_preview_brightness_spinbutton">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                        <property name="text" translatable="yes">0</property>
+                                        <property name="adjustment">trans_bg_icon_preview_brightness_adjustment</property>
+                                        <layout>
+                                          <property name="row">2</property>
+                                          <property name="column">1</property>
+                                        </layout>
+                                      </object>
+                                    </child>
+                                    <layout>
+                                      <property name="row">1</property>
+                                      <property name="column">0</property>
+                                      <property name="column-span">2</property>
+                                    </layout>
+                                  </object>
+                                </child>
                               </object>
                             </child>
                           </object>

--- a/appIcons.js
+++ b/appIcons.js
@@ -609,7 +609,7 @@ var taskbarAppIcon = Utils.defineClass({
 
         if (this._checkIfFocusedApp() && !this.isLauncher &&  
         (!this.window || isFocused) && !this._isThemeProvidingIndicator() && this._checkIfMonitorHasFocus()){
-            let dominantColor = this._getFocusedAppDominantColor();
+            let dominantColor = this._getAppDominantColor();
             if (dominantColor && this.parentPanelColor != dominantColor){
                 global.log('Emitting "changed::focus-dominant-color" with value ' + dominantColor);
                 global.dashToPanel.emit('changed::focus-dominant-color', dominantColor);
@@ -1092,7 +1092,7 @@ var taskbarAppIcon = Utils.defineClass({
         return color;
     },
 
-    _getFocusedAppDominantColor: function() {
+    _getAppDominantColor: function() {
         let dce = new Utils.DominantColorExtractor(this.app);
         let palette = dce._getColorPalette();
         if (palette) return palette.original;
@@ -1101,7 +1101,7 @@ var taskbarAppIcon = Utils.defineClass({
 
     _getFocusHighlightColor: function() {
         if (Me.settings.get_boolean('focus-highlight-dominant')) {
-            let domColor = this._getFocusedAppDominantColor();
+            let domColor = this._getAppDominantColor();
             if (domColor !== undefined) return domColor;
         }
         return Me.settings.get_string('focus-highlight-color');

--- a/appIcons.js
+++ b/appIcons.js
@@ -611,7 +611,6 @@ var taskbarAppIcon = Utils.defineClass({
         (!this.window || isFocused) && !this._isThemeProvidingIndicator() && this._checkIfMonitorHasFocus()){
             let dominantColor = this._getAppDominantColor();
             if (dominantColor && this.parentPanelColor != dominantColor){
-                global.log('Emitting "changed::focus-dominant-color" with value ' + dominantColor);
                 global.dashToPanel.emit('changed::focus-dominant-color', dominantColor);
             }
                     

--- a/appIcons.js
+++ b/appIcons.js
@@ -604,6 +604,10 @@ var taskbarAppIcon = Utils.defineClass({
             }
 
             let highlightColor = this._getFocusHighlightColor();
+            if (this.parentPanelColor != highlightColor){
+                global.log('Emitting "changed::focus-highlight-color" with value ' + highlightColor);
+                global.dashToPanel.emit('changed::focus-highlight-color', highlightColor);
+            }
             inlineStyle += "background-color: " + cssHexTocssRgba(highlightColor, Me.settings.get_int('focus-highlight-opacity') * 0.01);
         }
         

--- a/prefs.js
+++ b/prefs.js
@@ -1009,12 +1009,26 @@ const Preferences = new Lang.Class({
 
         this._builder.get_object('trans_bg_icon_brightness_spinbutton').set_value(this._settings.get_double('trans-panel-dominant-color-brightness') * 100);
         this._builder.get_object('trans_bg_icon_brightness_spinbutton').connect('value-changed', Lang.bind(this, function (widget) {
-            this._settings.set_double('trans-panel-dominant-color-brightness', widget.get_value() * 0.01);
+            if (widget.get_value() < 1){
+                // Somehow fixes bug that resets brightness to 0.5 when user sets to 0
+                this._settings.set_double('trans-panel-dominant-color-brightness', 0.001);
+            }
+            else
+            {
+                this._settings.set_double('trans-panel-dominant-color-brightness', widget.get_value() * 0.01);
+            }
         }));
 
         this._builder.get_object('trans_bg_icon_preview_brightness_spinbutton').set_value(this._settings.get_double('trans-preview-dominant-color-brightness') * 100);
         this._builder.get_object('trans_bg_icon_preview_brightness_spinbutton').connect('value-changed', Lang.bind(this, function (widget) {
-            this._settings.set_double('trans-preview-dominant-color-brightness', widget.get_value() * 0.01);
+            if (widget.get_value() < 1){
+                // Somehow fixes bug that resets brightness to 0.5 when user sets to 0
+                this._settings.set_double('trans-preview-dominant-color-brightness', 0.001);
+            }
+            else
+            {
+                this._settings.set_double('trans-preview-dominant-color-brightness', widget.get_value() * 0.01);
+            }
         }));
 
         this._settings.bind('trans-use-dynamic-opacity',

--- a/prefs.js
+++ b/prefs.js
@@ -965,6 +965,11 @@ const Preferences = new Lang.Class({
                             this._builder.get_object('trans_bg_color_colorbutton'),
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT);
+        
+        this._settings.bind('trans-use-dominant-icon-color',
+                            this._builder.get_object('trans_bg_icon_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
 
         let rgba = new Gdk.RGBA();
         rgba.parse(this._settings.get_string('trans-bg-color'));

--- a/prefs.js
+++ b/prefs.js
@@ -970,6 +970,11 @@ const Preferences = new Lang.Class({
                             this._builder.get_object('trans_bg_icon_switch'),
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
+        
+        this._settings.bind('trans-apply-dominant-color-to-preview',
+                            this._builder.get_object('trans_bg_icon_preview_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
 
         let rgba = new Gdk.RGBA();
         rgba.parse(this._settings.get_string('trans-bg-color'));
@@ -1005,6 +1010,11 @@ const Preferences = new Lang.Class({
         this._builder.get_object('trans_bg_icon_brightness_spinbutton').set_value(this._settings.get_double('trans-panel-dominant-color-brightness') * 100);
         this._builder.get_object('trans_bg_icon_brightness_spinbutton').connect('value-changed', Lang.bind(this, function (widget) {
             this._settings.set_double('trans-panel-dominant-color-brightness', widget.get_value() * 0.01);
+        }));
+
+        this._builder.get_object('trans_bg_icon_preview_brightness_spinbutton').set_value(this._settings.get_double('trans-preview-dominant-color-brightness') * 100);
+        this._builder.get_object('trans_bg_icon_preview_brightness_spinbutton').connect('value-changed', Lang.bind(this, function (widget) {
+            this._settings.set_double('trans-preview-dominant-color-brightness', widget.get_value() * 0.01);
         }));
 
         this._settings.bind('trans-use-dynamic-opacity',

--- a/prefs.js
+++ b/prefs.js
@@ -1002,6 +1002,11 @@ const Preferences = new Lang.Class({
             this._settings.set_double('trans-panel-opacity', widget.get_value() * 0.01);
         }));
 
+        this._builder.get_object('trans_bg_icon_brightness_spinbutton').set_value(this._settings.get_double('trans-panel-dominant-color-brightness') * 100);
+        this._builder.get_object('trans_bg_icon_brightness_spinbutton').connect('value-changed', Lang.bind(this, function (widget) {
+            this._settings.set_double('trans-panel-dominant-color-brightness', widget.get_value() * 0.01);
+        }));
+
         this._settings.bind('trans-use-dynamic-opacity',
                             this._builder.get_object('trans_dyn_switch'),
                             'active',

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -264,6 +264,11 @@
       <summary>Panel opacity</summary>
       <description>Custom opacity for the panel</description>
     </key>
+    <key type="d" name="trans-panel-dominant-color-brightness">
+      <default>0.5</default>
+      <summary>Panel dominant color brightness</summary>
+      <description>Modify brightness of dominant color of app icon used as panel background color</description>
+    </key>
     <key name="trans-dynamic-behavior" enum="org.gnome.shell.extensions.dash-to-panel.proximityBehavior">
       <default>'ALL_WINDOWS'</default>
       <summary>Dynamic opacity behavior</summary>

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -244,6 +244,11 @@
       <summary>Override panel theme background color with dominant icon color</summary>
       <description>Replace current theme background color for the panel with the dominant color of the focused app icon. Falls back to overridden background color or theme color if no app is focused or if the Activities overlay is opened.</description>
     </key>
+    <key type="b" name="trans-apply-dominant-color-to-preview">
+      <default>false</default>
+      <summary>Apply to window preview</summary>
+      <description>Apply dominant color to window preview</description>
+    </key>
     <key type="s" name="trans-bg-color">
       <default>"#000"</default>
       <summary>Custom background color</summary>
@@ -268,6 +273,11 @@
       <default>0.5</default>
       <summary>Panel dominant color brightness</summary>
       <description>Modify brightness of dominant color of app icon used as panel background color</description>
+    </key>
+    <key type="d" name="trans-preview-dominant-color-brightness">
+      <default>0.5</default>
+      <summary>Window preview dominant color brightness</summary>
+      <description>Modify brightness of dominant color of app icon used as window preview background color</description>
     </key>
     <key name="trans-dynamic-behavior" enum="org.gnome.shell.extensions.dash-to-panel.proximityBehavior">
       <default>'ALL_WINDOWS'</default>

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -275,7 +275,7 @@
       <description>Modify brightness of dominant color of app icon used as panel background color</description>
     </key>
     <key type="d" name="trans-preview-dominant-color-brightness">
-      <default>0.5</default>
+      <default>0.15</default>
       <summary>Window preview dominant color brightness</summary>
       <description>Modify brightness of dominant color of app icon used as window preview background color</description>
     </key>

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -239,6 +239,11 @@
       <summary>Override theme background color</summary>
       <description>Replace current theme background color for the panel</description>
     </key>
+    <key type="b" name="trans-use-dominant-icon-color">
+      <default>false</default>
+      <summary>Override panel theme background color with dominant icon color</summary>
+      <description>Replace current theme background color for the panel with the dominant color of the focused app icon. Falls back to overridden background color or theme color if no app is focused or if the Activities overlay is opened.</description>
+    </key>
     <key type="s" name="trans-bg-color">
       <default>"#000"</default>
       <summary>Custom background color</summary>

--- a/taskbar.js
+++ b/taskbar.js
@@ -391,6 +391,13 @@ var taskbar = Utils.defineClass({
                     'notify::pageSize'
                 ],
                 () => this._onScrollSizeChange(adjustment)
+            ],
+            [
+                global.dashToPanel,
+                'changed::focus-highlight-color',
+                Lang.bind(this, function(_, color){
+                    this._updatePanelAppColor(color);
+                })
             ]
         );
 
@@ -689,9 +696,9 @@ var taskbar = Utils.defineClass({
         }
 
         appIcon.connect('menu-state-changed',
-                        Lang.bind(this, function(appIcon, opened) {
-                            this._itemMenuStateChanged(item, opened);
-                        }));
+            Lang.bind(this, function(appIcon, opened) {
+                this._itemMenuStateChanged(item, opened);
+            }));
 
         let item = new TaskbarItemContainer();
 
@@ -700,6 +707,11 @@ var taskbar = Utils.defineClass({
 
         item.setChild(appIcon.actor);
         appIcon._dashItemContainer = item;
+        this._signalsHandler.add(
+            global.dashToPanel,
+            'changed::focus-highlight-color',
+            (_, color) => appIcon.parentPanelColor = this.dtpPanel.dynamicTransparency.currentBackgroundAppColor
+        );
 
         appIcon.actor.connect('notify::hover', Lang.bind(this, function() {
             if (appIcon.actor.hover){
@@ -739,7 +751,7 @@ var taskbar = Utils.defineClass({
                     appIcon._menu._boxPointer.yOffset = -y_shift;
                 }
         }));
-        
+
         // Override default AppIcon label_actor, now the
         // accessible_name is set at DashItemContainer.setLabelText
         appIcon.actor.label_actor = null;
@@ -749,6 +761,13 @@ var taskbar = Utils.defineClass({
         this._hookUpLabel(item, appIcon);
 
         return item;
+    },
+
+    _updatePanelAppColor: function (color){
+        global.log('color: ' + color);
+        if (color){
+            this.dtpPanel.dynamicTransparency.setBackgroundColorToAppColor(color);
+        }
     },
 
     // Return an array with the "proper" appIcons currently in the taskbar

--- a/taskbar.js
+++ b/taskbar.js
@@ -394,7 +394,7 @@ var taskbar = Utils.defineClass({
             ],
             [
                 global.dashToPanel,
-                'changed::focus-highlight-color',
+                'changed::focus-dominant-color',
                 Lang.bind(this, function(_, color){
                     this._updatePanelAppColor(color);
                 })
@@ -709,7 +709,7 @@ var taskbar = Utils.defineClass({
         appIcon._dashItemContainer = item;
         this._signalsHandler.add(
             global.dashToPanel,
-            'changed::focus-highlight-color',
+            'changed::focus-dominant-color',
             (_, color) => appIcon.parentPanelColor = this.dtpPanel.dynamicTransparency.currentBackgroundAppColor
         );
 

--- a/taskbar.js
+++ b/taskbar.js
@@ -764,7 +764,6 @@ var taskbar = Utils.defineClass({
     },
 
     _updatePanelAppColor: function (color){
-        global.log('color: ' + color);
         if (color){
             this.dtpPanel.dynamicTransparency.setBackgroundColorToAppColor(color);
         }

--- a/transparency.js
+++ b/transparency.js
@@ -211,9 +211,7 @@ var DynamicTransparency = Utils.defineClass({
             let blendValue = overrideValue || Me.settings.get_double('trans-panel-dominant-color-brightness') || 0.5;
 
             // Apply Linear Light blending (black if value is 0, white if value is 1, same color as input if value is 0.5)
-            log('outputColor BEFORE linearlight: r: ' + outputColor.red + ", g: " + outputColor.green + ", b: " + outputColor.blue + ", blendValue: " + blendValue);
             outputColor = this._linearLight(outputColor, blendValue);
-            log('outputColor AFTER linearlight: r: ' + outputColor.red + ", g: " + outputColor.green + ", b: " + outputColor.blue + ", blendValue: " + blendValue);
         }
         return outputColor;
     },

--- a/transparency.js
+++ b/transparency.js
@@ -226,9 +226,10 @@ var DynamicTransparency = Utils.defineClass({
             this.backgroundColorRgbPreview = this.backgroundColorRgb;
         }
         if (Me.settings.get_boolean('trans-apply-dominant-color-to-preview')){
+            let prevBgColor = this.backgroundColorRgb;
             this.backgroundColorRgb = this._modifyColorToDominantAppColor(this.backgroundColorRgb);
             this.backgroundColorRgbPreview = this._modifyColorToDominantAppColor(
-                this.backgroundColorRgb,
+                prevBgColor,
                 Me.settings.get_double('trans-preview-dominant-color-brightness')
             );
         }

--- a/transparency.js
+++ b/transparency.js
@@ -87,7 +87,8 @@ var DynamicTransparency = Utils.defineClass({
                 Me.settings,
                 [
                     'changed::trans-use-custom-bg',
-                    'changed::trans-bg-color'
+                    'changed::trans-bg-color',
+                    'changed::trans-use-dominant-icon-color'
                 ],
                 () => this._updateColorAndSet()
             ],
@@ -187,9 +188,16 @@ var DynamicTransparency = Utils.defineClass({
     },
 
     _updateColor: function(themeBackground) {
-        this.backgroundColorRgb = Me.settings.get_boolean('trans-use-custom-bg') ?
-                                  Me.settings.get_string('trans-bg-color') :
-                                  (themeBackground || this._getThemeBackground());
+        this.backgroundColorRgb = (themeBackground || this._getThemeBackground());
+        if (Me.settings.get_boolean('trans-use-custom-bg')){
+            this.backgroundColorRgb = Me.settings.get_string('trans-bg-color');
+        }
+        if (Me.settings.get_boolean('trans-use-dominant-icon-color')){
+            this.backgroundColorRgb = this.currentBackgroundAppColor;
+        }
+        // this.backgroundColorRgb = Me.settings.get_boolean('trans-use-custom-bg') ?
+        //                           Me.settings.get_string('trans-bg-color') :
+        //                           (themeBackground || this._getThemeBackground());
     },
 
     _updateAlpha: function(themeBackground) {
@@ -216,11 +224,11 @@ var DynamicTransparency = Utils.defineClass({
 
     setBackgroundColorToAppColor: function(color){
         this.currentBackgroundAppColor = Utils.getrgbaColor(color, this.alpha);
-        this._setBackground();
+        this._updateColorAndSet();
     },
 
     _setBackground: function() {
-        this.currentBackgroundColor = this.currentBackgroundAppColor || Utils.getrgbaColor(this.backgroundColorRgb, this.alpha);
+        this.currentBackgroundColor = Utils.getrgbaColor(this.backgroundColorRgb, this.alpha);
 
         let transition = 'transition-duration:' + this.animationDuration;
         let cornerStyle = '-panel-corner-background-color: ' + this.currentBackgroundColor + transition;

--- a/transparency.js
+++ b/transparency.js
@@ -214,12 +214,17 @@ var DynamicTransparency = Utils.defineClass({
         }
     },
 
+    setBackgroundColorToAppColor: function(color){
+        this.currentBackgroundAppColor = Utils.getrgbaColor(color, this.alpha);
+        this._setBackground();
+    },
+
     _setBackground: function() {
-        this.currentBackgroundColor = Utils.getrgbaColor(this.backgroundColorRgb, this.alpha);
+        this.currentBackgroundColor = this.currentBackgroundAppColor || Utils.getrgbaColor(this.backgroundColorRgb, this.alpha);
 
         let transition = 'transition-duration:' + this.animationDuration;
         let cornerStyle = '-panel-corner-background-color: ' + this.currentBackgroundColor + transition;
-
+        // global.log('panel background-color: ' + this.currentBackgroundColor);
         this._dtpPanel.set_style('background-color: ' + this.currentBackgroundColor + transition + this._complementaryStyles);
         
         if (this._dtpPanel.geom.position == St.Side.TOP) {

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -193,7 +193,7 @@ var PreviewMenu = Utils.defineClass({
                 this.set_height(this.clipHeight);
                 this.menu.show();
                 
-                setStyle(this.menu, 'background: ' + Utils.getrgbaColor(this.panel.dynamicTransparency.backgroundColorRgb, alphaBg));
+                setStyle(this.menu, 'background: ' + Utils.getrgbaColor(this.panel.dynamicTransparency.backgroundColorRgbPreview, alphaBg));
             }
 
             this._mergeWindows(appIcon);
@@ -519,8 +519,8 @@ var PreviewMenu = Utils.defineClass({
 
     _getFadeWidget: function(end) {
         let x = 0, y = 0;
-        let startBg = Utils.getrgbaColor(this.panel.dynamicTransparency.backgroundColorRgb, Math.min(alphaBg + .1, 1));
-        let endBg = Utils.getrgbaColor(this.panel.dynamicTransparency.backgroundColorRgb, 0)
+        let startBg = Utils.getrgbaColor(this.panel.dynamicTransparency.backgroundColorRgbPreview, Math.min(alphaBg + .1, 1));
+        let endBg = Utils.getrgbaColor(this.panel.dynamicTransparency.backgroundColorRgbPreview, 0)
         let fadeStyle = 'background-gradient-start:' + startBg + 
                         'background-gradient-end:' + endBg + 
                         'background-gradient-direction:' + this.panel.getOrientation();
@@ -997,7 +997,7 @@ var Preview = Utils.defineClass({
             alpha = alphaBg;
         }
 
-        return Utils.getrgbaColor(this._previewMenu.panel.dynamicTransparency.backgroundColorRgb, alpha, offset);
+        return Utils.getrgbaColor(this._previewMenu.panel.dynamicTransparency.backgroundColorRgbPreview, alpha, offset);
     },
 
     _addClone: function(newCloneBin, animateSize) {


### PR DESCRIPTION
This pull request adds a feature I've wanted for a while. Using the existing functionality of getting the dominant color from the app icon to highlight the app, I have extended this functionality to the panels.

New features:
- Ability to turn on and off panel coloring to dominant app color
- Ability to change brightness of panel color (using linear light formula)
- Ability to turn on and off window preview coloring to dominant app color
- Ability to change brightness of window preview color (using linear light formula)

I currently haven't upgraded to Gnome 41 yet, so this extension was built using the gnome-40 version as a base. Feel free to upgrade it to Gnome 41 if you like

https://user-images.githubusercontent.com/16272815/150729313-67c40ce4-6d35-434f-8aeb-c382d8270e78.mp4

.