### PR TITLE
Add 'Toggle single / Cycle multiple' option to all click methods

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -490,6 +490,7 @@
                           <item id="CYCLE" translatable="yes">Cycle through windows</item>
                           <item id="CYCLE-MIN" translatable="yes">Cycle windows + minimize</item>
                           <item id="TOGGLE-SHOWPREVIEW" translatable="yes">Toggle single / Preview multiple</item>
+                          <item id="TOGGLE-CYCLE" translatable="yes">Toggle single / Cycle multiple</item>
                           <item id="QUIT" translatable="yes">Quit</item>
                         </items>
                         <layout>
@@ -561,6 +562,7 @@
                           <item id="CYCLE" translatable="yes">Cycle through windows</item>
                           <item id="CYCLE-MIN" translatable="yes">Cycle windows + minimize</item>
                           <item id="TOGGLE-SHOWPREVIEW" translatable="yes">Toggle single / Preview multiple</item>
+                          <item id="TOGGLE-CYCLE" translatable="yes">Toggle single / Cycle multiple</item>
                           <item id="QUIT" translatable="yes">Quit</item>
                         </items>
                         <layout>
@@ -6482,6 +6484,7 @@
                                       <item id="CYCLE-MIN" translatable="yes">Cycle windows + minimize</item>
                                       <item id="CYCLE" translatable="yes">Cycle through windows</item>
                                       <item id="TOGGLE-SHOWPREVIEW" translatable="yes">Toggle single / Preview multiple</item>
+                                      <item id="TOGGLE-CYCLE" translatable="yes">Toggle single / Cycle multiple</item>
                                       <item id="MINIMIZE" translatable="yes">Toggle windows</item>
                                       <item id="RAISE" translatable="yes">Raise windows</item>
                                       <item id="LAUNCH" translatable="yes">Launch new instance</item>


### PR DESCRIPTION
The 'Toggle single / Cycle multiple' option was added by https://github.com/home-sweet-gnome/dash-to-panel/pull/1195, but for some reason only to the shift+click action. This adds it to the other click methods (click, middle click, shift+middle click)