### PR TITLE
Toggle for notification counter badge

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -5835,6 +5835,51 @@
                         </child>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkListBoxRow" id="show_notification_badge_row">
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <child>
+                          <object class="GtkGrid" id="show_notification_badge_grid">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="row_spacing">6</property>
+                            <property name="column_spacing">32</property>
+                            <child>
+                              <object class="GtkSwitch" id="show_notification_badge_switch">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <layout>
+                                  <property name="row">0</property>
+                                  <property name="column">1</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="show_notification_badge_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="label" translatable="yes">Show notification counter badge</property>
+                                <property name="use_markup">True</property>
+                                <property name="xalign">0</property>
+                                <layout>
+                                  <property name="row">0</property>
+                                  <property name="column">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                 </child>
                 <child type="label_item">

--- a/panel.js
+++ b/panel.js
@@ -1421,8 +1421,14 @@ var Panel = GObject.registerClass({
     }
 
     _initProgressManager() {
-        if(!this.progressManager && (Me.settings.get_boolean('progress-show-bar') || Me.settings.get_boolean('progress-show-count')))
+        const progressVisible = Me.settings.get_boolean('progress-show-bar');
+        const countVisible = Me.settings.get_boolean('progress-show-count');
+        const pm = this.progressManager;
+
+        if(!pm && (progressVisible || countVisible))
             this.progressManager = new Progress.ProgressManager();
+        else if (pm)
+            Object.keys(pm._entriesByDBusName).forEach((k) => pm._entriesByDBusName[k].setCountVisible(countVisible));
     }
 });
 

--- a/prefs.js
+++ b/prefs.js
@@ -1592,6 +1592,11 @@ const Preferences = class {
                             'sensitive',
                             Gio.SettingsBindFlags.DEFAULT | Gio.SettingsBindFlags.INVERT_BOOLEAN);
 
+        this._settings.bind('progress-show-count',
+                            this._builder.get_object('show_notification_badge_switch'),
+                            'active',
+                            Gio.SettingsBindFlags.DEFAULT);
+
         this._builder.get_object('group_apps_label_font_color_colorbutton').connect('color-set',  (button) => {
             let rgba = button.get_rgba();
             let css = rgba.to_string();


### PR DESCRIPTION
I found it a little weird that the setting for the notification badge is hidden in the schema file without an appropriate UI to toggle it. 

Before this PR, to toggle the notification badge one would have to:
1. Modify the `schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml` file at `progress-show-count` key.
2. Rebuild the schema via `glib-compile-schemas schemas`
3. Re-log.

With this, PR one just has to toggle this switch in the `Behavior` tab:
![image](https://user-images.githubusercontent.com/19696509/162559003-1e23561d-34db-4a6b-bae0-8bde24e73fae.png)

On:
![image](https://user-images.githubusercontent.com/19696509/162559032-188d1939-92d1-4d3a-8b01-754d73396a3d.png)

Off:
![image](https://user-images.githubusercontent.com/19696509/162559037-65a452d8-7150-43a3-93c7-2896a676945d.png)



