### PR TITLE
Update Polish translation to correspond with Gnome

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -198,7 +198,7 @@ msgstr "Nowe okno"
 
 #: appIcons.js:1398 appIcons.js:1458 appIcons.js:1460 Settings.ui.h:10
 msgid "Quit"
-msgstr "Zamknięcie okna"
+msgstr "Zakończ"
 
 #: appIcons.js:1460
 msgid "Windows"


### PR DESCRIPTION
When right-clicking icon on panel the Polish translation for "Quit" is different and too verbose than what I get in dash.
Gnome dash (activities view):
![Zrzut ekranu z 2022-05-16 15-13-00](https://user-images.githubusercontent.com/925302/168601728-42616478-b8ff-4205-8a5a-18101f7d9214.png)

Dash to Panel:
![Zrzut ekranu z 2022-05-16 15-13-21](https://user-images.githubusercontent.com/925302/168601785-51d2425f-5a03-4fbb-8296-333cfc73dac7.png)

