### PR TITLE
Change first launch action fixes #1622

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1023,7 +1023,7 @@ var TaskbarAppIcon = GObject.registerClass({
     }
 
     _launchNewInstance() {
-        if (this.app.can_open_new_window()) {
+        if (this.app.can_open_new_window() && this.app.state == Shell.AppState.RUNNING) {
             let appActions = this.app.get_app_info().list_actions();
             let newWindowIndex = appActions.indexOf('new-window');
 


### PR DESCRIPTION
Launching an application should perform the default action for that application instead of the "open new window" action when it's not running.