### PR TITLE
Fixes for panel reloads

### DIFF
--- a/panelStyle.js
+++ b/panelStyle.js
@@ -273,7 +273,7 @@ var PanelStyle = class {
     }
     
     _overrideStyle(actor, styleLine, operationIdx) {
-        if (actor._dtp_original_inline_style === undefined) {
+        if (actor._dtp_original_inline_style === undefined && actor.get_style !== undefined) {
             actor._dtp_original_inline_style = actor.get_style();
         }
 
@@ -285,7 +285,9 @@ var PanelStyle = class {
         let newStyleLine = '';
         for(let i in actor._dtp_style_overrides)
             newStyleLine += actor._dtp_style_overrides[i] + '; ';
-        actor.set_style(newStyleLine + (actor._dtp_original_inline_style || ''));
+        if (actor.set_style !== undefined) {
+            actor.set_style(newStyleLine + (actor._dtp_original_inline_style || ''));
+        }
      }
 
     _restoreOriginalStyle(actor) {

--- a/panelStyle.js
+++ b/panelStyle.js
@@ -295,7 +295,8 @@ var PanelStyle = class {
             delete actor._dtp_style_overrides;
         }
 
-        if (actor.has_style_class_name('panel-button')) {
+        if (actor.has_style_class_name !== undefined
+                && actor.has_style_class_name('panel-button')) {
             this._refreshPanelButton(actor);
         }
     }

--- a/taskbar.js
+++ b/taskbar.js
@@ -928,6 +928,8 @@ var Taskbar = class {
             return;
         }
 
+        this.dtpPanel._initProgressManager();
+
         //get the currently displayed appIcons
         let currentAppIcons = this._getTaskbarIcons();
         let expectedAppInfos = this.getAppInfos();


### PR DESCRIPTION
Certain extensions such as (my fork of) PaperWM delete the Activities button, which breaks Dash to Panel's resume action.

If my Javascript isn't too rusty, this should not have any adverse effects on anyone else's system.