### PR TITLE
Enable notification badges

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -409,6 +409,11 @@ var TaskbarAppIcon = GObject.registerClass({
         });
     }
 
+    updateBadge(count, enable) {
+        this._progressIndicator.setNotificationBadge(count);
+        this._progressIndicator.toggleNotificationBadge(enable);
+    }
+
     _onAnimateAppiconHoverChanged() {
         if (Me.settings.get_boolean('animate-appicon-hover')) {
             this._container.add_style_class_name('animate-appicon-hover');

--- a/taskbar.js
+++ b/taskbar.js
@@ -288,6 +288,8 @@ var Taskbar = class {
 
         this.iconAnimator = new PanelManager.IconAnimator(this.dtpPanel.panel);
 
+        this._messageTray = Main.messageTray;
+
         this._signalsHandler.add(
             [
                 this.dtpPanel.panel,
@@ -394,6 +396,21 @@ var Taskbar = class {
                     'notify::pageSize'
                 ],
                 () => this._onScrollSizeChange(adjustment)
+            ],
+            [
+                this._messageTray,
+                'source-added',
+                this._onMessageTraySource.bind(this)
+            ],
+            [
+                this._messageTray,
+                'source-removed',
+                this._onMessageTraySource.bind(this)
+            ],
+            [
+                this._messageTray,
+                'queue-changed',
+                this._onMessageTrayQueueChanged.bind(this)
             ]
         );
 
@@ -795,6 +812,28 @@ var Taskbar = class {
 
         appIcons.filter(icon => icon.constructor === AppIcons.TaskbarAppIcon).forEach(icon => {
             icon.updateIcon();
+        });
+    }
+
+    _onMessageTraySource(source) {
+        // The source from signals does not contain the policy, and
+        // source-removed does not even contain any id. Ignore and
+        // always handle changes as if there was any other queue change.
+        this._onMessageTrayQueueChanged();
+    }
+
+    _onMessageTrayQueueChanged() {
+        this._getAppIcons().filter(icon => icon.constructor === AppIcons.TaskbarAppIcon).forEach(icon => {
+            let count = 0;
+            let enable = false;
+            for (let source of this._messageTray.getSources()) {
+                if (icon.app.id === `${source.policy.id}.desktop`) {
+                    count = source.count;
+                    enable = source.policy.enable;
+                }
+            }
+
+            icon.updateBadge(count, enable);
         });
     }
 


### PR DESCRIPTION
I'm noticing the missing notification counter badges mentioned in #1695 as well. This PR is based on the patch from @vaskion, but omits the animation changes.