### PR TITLE
Fix Desktop Icons DND with raised, animated, clones.

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -127,7 +127,7 @@ var TaskbarAppIcon = GObject.registerClass({
 
         this._timeoutsHandler = new Utils.TimeoutsHandler();
 
-		// Fix touchscreen issues before the listener is added by the parent constructor.
+        // Fix touchscreen issues before the listener is added by the parent constructor.
         this._onTouchEvent = function(actor, event) {
             if (event.type() == Clutter.EventType.TOUCH_BEGIN) {
                 // Open the popup menu on long press.
@@ -286,6 +286,8 @@ var TaskbarAppIcon = GObject.registerClass({
             reactive: false,
             x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER,
         });
+
+        clone._delegate = this._delegate;
 
         // "clone" of this.actor
         return new St.Button({


### PR DESCRIPTION
Currently, when animations are enabled, the raised, animated clones of the appIcons break gnome DND functionality on the appIcon.

I am the author of Gtk4-DING, and use the DND functions available on the base appIcon class of the Gnome appIcon that is extended by your extension. This functionality enables dropping files from the Gtk4-DING desktop onto the dash-to-panel or dash-to-dock extension to open them etc.

Although this works well, when the panel is animated, the raised animated clones lack the basic Gnome DND functions. That breaks drag and drop functionality, only when the panel is animated. 

This enables DND functionality on all raised clones when the panel is animated.