### PR TITLE
Add "None" DOT_STYLE to completely remove dots in Taskbar

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -4892,6 +4892,7 @@
                                       <item id="SOLID" translatable="yes">Solid</item>
                                       <item id="CILIORA" translatable="yes">Ciliora</item>
                                       <item id="METRO" translatable="yes">Metro</item>
+                                      <item id="NONE" translatable="no">None</item>
                                     </items>
                                   </object>
                                 </child>
@@ -4934,6 +4935,7 @@
                                   <item id="SOLID" translatable="yes">Solid</item>
                                   <item id="CILIORA" translatable="yes">Ciliora</item>
                                   <item id="METRO" translatable="yes">Metro</item>
+                                  <item id="NONE" translatable="no">None</item>
                                 </items>
                               </object>
                             </child>

--- a/appIcons.js
+++ b/appIcons.js
@@ -80,7 +80,8 @@ let DOT_STYLE = {
     SEGMENTED: "SEGMENTED",
     CILIORA: "CILIORA",
     METRO: "METRO",
-    SOLID: "SOLID"
+    SOLID: "SOLID",
+    NONE: "NONE"
 }
 
 let DOT_POSITION = {
@@ -1185,6 +1186,8 @@ var TaskbarAppIcon = GObject.registerClass({
             };
         
             switch (type) {
+                case DOT_STYLE.NONE:
+                    break;
                 case DOT_STYLE.CILIORA:
                     spacing = size;
                     length = areaSize - (size * (n - 1)) - (spacing * (n - 1));

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -8,6 +8,7 @@
     <value value='4' nick='SOLID'/>
     <value value='5' nick='CILIORA'/>
     <value value='6' nick='METRO'/>
+    <value value='7' nick='NONE'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-panel.clickAction'>
     <value value='0' nick='RAISE'/>


### PR DESCRIPTION
I keep all my apps in the Applications Menu: i don't like pinning applications to the Dash.  
In the Dash i want to see only running applications with an indicator on the focused one.  
To accomplish this i've added a new style called "None" for the _DOT\_STYLE_.  
This is an example with the option "Running indicator style (Unfocused apps)" set to _None_:
![screen](https://user-images.githubusercontent.com/46603573/211116774-175fffcc-b33f-4c7c-85a4-47734ddb834f.png)
![Screenshot from 2023-01-07 14-04-46](https://user-images.githubusercontent.com/46603573/211152177-e2a6605d-0edc-4253-8f44-83c33b926c33.png)

**\m/**