### PR TITLE
Makefile: support system-wide installation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,12 @@ EXTRA_IMAGES = highlight_stacked_bg.svg highlight_stacked_bg_2.svg highlight_sta
 TOLOCALIZE =  prefs.js appIcons.js
 MSGSRC = $(wildcard po/*.po)
 ifeq ($(strip $(DESTDIR)),)
+	INSTALLTYPE = local
 	INSTALLBASE = $(HOME)/.local/share/gnome-shell/extensions
 else
+	INSTALLTYPE = system
 	INSTALLBASE = $(DESTDIR)/usr/share/gnome-shell/extensions
+	SHARE_PREFIX = $(DESTDIR)/usr/share
 endif
 INSTALLNAME = dash-to-panel@jderose9.github.com
 
@@ -71,6 +74,12 @@ install-local: _build
 	rm -rf $(INSTALLBASE)/$(INSTALLNAME)
 	mkdir -p $(INSTALLBASE)/$(INSTALLNAME)
 	cp -r ./_build/* $(INSTALLBASE)/$(INSTALLNAME)/
+ifeq ($(INSTALLTYPE),system)
+	rm -r $(INSTALLBASE)/$(INSTALLNAME)/schemas $(INSTALLBASE)/$(INSTALLNAME)/locale
+	mkdir -p $(SHARE_PREFIX)/glib-2.0/schemas $(SHARE_PREFIX)/locale
+	cp -r ./schemas/*gschema.* $(SHARE_PREFIX)/glib-2.0/schemas
+	cp -r ./_build/locale/* $(SHARE_PREFIX)/locale
+endif
 	-rm -fR _build
 	echo done
 


### PR DESCRIPTION
System-wide installation should install locale/ and gsettings schema in system directory. This enables override supports, locale stripping and not shipping pre-compiled schema file.

Cherry-picked-from: micheleg/dash-to-dock@4dd565dad920ce44303635b550a39bbdbe34fb70