### PR TITLE
Backport of fixes for issue #1663 to v42 (Ubuntu 20.04)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -45,7 +45,7 @@ let extensionSystem = (Main.extensionManager || imports.ui.extensionSystem);
 
 function init() {
     Convenience.initTranslations(Utils.TRANSLATION_DOMAIN);
-    
+
     //create an object that persists until gnome-shell is restarted, even if the extension is disabled
     Me.persistentStorage = {};
 }
@@ -58,10 +58,10 @@ function enable() {
         }
     });
 
-    //create a global object that can emit signals and conveniently expose functionalities to other extensions 
+    //create a global object that can emit signals and conveniently expose functionalities to other extensions
     global.dashToPanel = {};
     Signals.addSignalMethods(global.dashToPanel);
-    
+
     _enable();
 }
 
@@ -94,13 +94,13 @@ function _enable() {
     panelManager = new PanelManager.dtpPanelManager();
 
     panelManager.enable();
-    
+
     Utils.removeKeybinding('open-application-menu');
     Utils.addKeybinding(
         'open-application-menu',
         new Gio.Settings({ schema_id: WindowManager.SHELL_KEYBINDINGS_SCHEMA }),
         Lang.bind(this, function() {
-            if(Me.settings.get_boolean('show-appmenu'))
+            if(Me.settings.get_boolean('show-appmenu') || !panelManager.primaryPanel)
                 Main.wm._toggleAppMenu();
             else
                 panelManager.primaryPanel.taskbar.popupFocusedAppSecondaryMenu();
@@ -111,7 +111,8 @@ function _enable() {
     // Pretend I'm the dash: meant to make appgrd swarm animation come from the
     // right position of the appShowButton.
     oldDash = Main.overview._dash;
-    Main.overview._dash = panelManager.primaryPanel.taskbar;
+    if(panelManager.primaryPanel)
+        Main.overview._dash = panelManager.primaryPanel.taskbar;
 }
 
 function disable(reset) {
@@ -123,7 +124,7 @@ function disable(reset) {
     delete Me.settings;
     oldDash = null;
     panelManager = null;
-    
+
     Utils.removeKeybinding('open-application-menu');
     Utils.addKeybinding(
         'open-application-menu',


### PR DESCRIPTION
This PR backports the fixes made to solve issue https://github.com/home-sweet-gnome/dash-to-panel/issues/1663 to version 42, which is the currently available version for Ubuntu 20.04.  
Ignore the request to merge into master, this PR is intended to be manually merged/cherry-picked on a new branch created from tag v42.

It would be cool if you could update the release on extensions.gnome.org, since in my experience this is the only issue seriously affecting the day-to-day usage on Ubuntu 20.04 of this awesome extension.
