### PR TITLE
fix: page titles, update: Turkish translation

### DIFF
--- a/po/tr.po
+++ b/po/tr.po
@@ -4,6 +4,7 @@
 #
 # Serdar Sağlam <teknomobil@yandex.com>, 2018, 2019.
 # Sabri Ünal <libreajans@gmail.com>, 2022.
+# Osman Coşkun <osman.coskun@pardus.org.tr>, 2023
 #
 # Çevirmenlere Not!
 # Bu çeviride aşırı yer kaplayan ve son kullanıcı tarafından kullanılmayan
@@ -196,7 +197,6 @@ msgid "%.1f"
 msgstr "%.1f"
 
 #: prefs.js:686
-#, javascript-format
 msgid "%d icon"
 msgid_plural "%d icons"
 msgstr[0] "%d simge"
@@ -343,7 +343,7 @@ msgstr "Henüz bir şey yok!"
 
 #: ui/BoxAdvancedOptions.ui.h:2
 msgid "For real..."
-msgstr ""
+msgstr "Gerçekten..."
 
 #: ui/BoxAnimateAppIconHoverOptions.ui.h:1
 msgid "Animation type"
@@ -459,7 +459,6 @@ msgid "Change opacity when a window gets closer than (px)"
 msgstr "Bir pencere şu kadar yaklaştığında matlığı değiştir (piksel)"
 
 #: ui/BoxDynamicOpacityOptions.ui.h:7
-#, no-c-format
 msgid "Change opacity to (%)"
 msgstr "Matlığı değiştir (%)"
 
@@ -509,16 +508,12 @@ msgid "Font color of the minimized application titles"
 msgstr "Küçültülmüş uygulama başlıklarının yazı tipi rengi"
 
 #: ui/BoxGroupAppsOptions.ui.h:10
-#, fuzzy
 msgid "Maximum width (px) of the application titles"
-msgstr "Uygulama başlıklarının azami genişliği (piksel) (varsayılan 160)"
+msgstr "Uygulama başlıklarının azami genişliği (piksel)"
 
 #: ui/BoxGroupAppsOptions.ui.h:11
-#, fuzzy
 msgid "(default is 160)"
-msgstr ""
-"Panel uzunluğu (%)\n"
-"(varsayılan 100)"
+msgstr "(varsayılan 160)"
 
 #: ui/BoxGroupAppsOptions.ui.h:12
 msgid "Use a fixed width for the application titles"
@@ -542,7 +537,6 @@ msgid "Use the favorite icons as application launchers"
 msgstr "Uygulama başlatıcıları olarak sık kullanılanlar simgelerini kullan"
 
 #: ui/BoxIntellihideOptions.ui.h:1
-#, fuzzy
 msgid "Only hide the panel when it is obstructed by windows"
 msgstr "Sadece pencere tarafından engellendiğinde paneli gizle "
 
@@ -568,14 +562,12 @@ msgid "Allow the panel to be revealed while in fullscreen mode"
 msgstr "Panelin tam ekran kipinde görünmesine izin ver"
 
 #: ui/BoxIntellihideOptions.ui.h:10
-#, fuzzy
 msgid "Only hide secondary panels"
 msgstr "Yalnızca ikincil panelleri gizle (çoklu ekran seçeneği gerekir)"
 
 #: ui/BoxIntellihideOptions.ui.h:11
-#, fuzzy
 msgid "(requires multi-monitors option)"
-msgstr "Yalnızca ikincil panelleri gizle (çoklu ekran seçeneği gerekir)"
+msgstr "(çoklu ekran seçeneği gerekir)"
 
 #: ui/BoxIntellihideOptions.ui.h:12
 msgid "Keyboard shortcut to reveal and hold the panel"
@@ -724,9 +716,7 @@ msgstr "Kısayol tuşları ile etkin"
 
 #: ui/BoxOverlayShortcut.ui.h:17
 msgid "Select which keyboard number keys are used to activate the hotkeys"
-msgstr ""
-"Kısayol tuşlarını etkinleştirmek için hangi klavye sayı tuşlarının "
-"kullanılacağını seçin"
+msgstr "Kısayol tuşlarını etkinleştirmek için hangi klavye sayı tuşlarının kullanılacağını seçin"
 
 #: ui/BoxOverlayShortcut.ui.h:18
 msgid "Number row"
@@ -746,9 +736,7 @@ msgstr "Fare kaydırma olayları arasındaki gecikme süresi (ms)"
 
 #: ui/BoxScrollIconOptions.ui.h:2 ui/BoxScrollPanelOptions.ui.h:2
 msgid "Use this value to limit the number of captured mouse scroll events."
-msgstr ""
-"Yakalanan fare kaydırma olaylarının sayısını sınırlamak için bu değeri "
-"kullan."
+msgstr "Yakalanan fare kaydırma olaylarının sayısını sınırlamak için bu değeri kullan."
 
 #: ui/BoxScrollPanelOptions.ui.h:3
 msgid "Show popup when changing workspace"
@@ -756,9 +744,7 @@ msgstr "Çalışma alanını değiştirirken açılır pencereyi göster"
 
 #: ui/BoxScrollPanelOptions.ui.h:4
 msgid "This affects workspace popup when scrolling on the panel only."
-msgstr ""
-"Bu, yalnızca panelde kaydırma yaparken çalışma alanı açılır penceresini "
-"etkiler."
+msgstr "Bu, yalnızca panelde kaydırma yaparken çalışma alanı açılır penceresini etkiler."
 
 #: ui/BoxSecondaryMenuOptions.ui.h:1
 msgid "Integrate <i>AppMenu</i> items"
@@ -769,7 +755,6 @@ msgid "<i>Show Details</i> menu item"
 msgstr "Ayrıntıları Göster <i>menü seçeneği</i>"
 
 #: ui/BoxShowApplicationsOptions.ui.h:1
-#, fuzzy
 msgid "Show Applications icon"
 msgstr "Uygulamaları Göster seçenekleri"
 
@@ -798,22 +783,20 @@ msgid "Fade duration (ms)"
 msgstr "Solma süresi (ms)"
 
 #: ui/BoxWindowPreviewOptions.ui.h:1
-#, fuzzy
 msgid "Time (ms) before showing"
-msgstr "Göstermeden önce geçen süre (ms) (varsayılan 400)"
+msgstr "Göstermeden önce geçen süre (ms)"
 
 #: ui/BoxWindowPreviewOptions.ui.h:2
 msgid "(400 is default)"
-msgstr ""
+msgstr "(varsayılan 400)"
 
 #: ui/BoxWindowPreviewOptions.ui.h:3
-#, fuzzy
 msgid "Time (ms) before hiding"
-msgstr "Gizlemeden önce geçen süre (ms) (varsayılan 100)"
+msgstr "Gizlemeden önce geçen süre (ms)"
 
 #: ui/BoxWindowPreviewOptions.ui.h:4
 msgid "(100 is default)"
-msgstr ""
+msgstr "(varsayılan 100)"
 
 #: ui/BoxWindowPreviewOptions.ui.h:5
 msgid "Immediate on application icon click"
@@ -936,7 +919,6 @@ msgid "Use custom opacity for the previews background"
 msgstr "Önizleme arka planıları için özel matlık kullan"
 
 #: ui/BoxWindowPreviewOptions.ui.h:35
-#, fuzzy
 msgid ""
 "If disabled, the previews background have the same opacity as the panel."
 msgstr ""
@@ -956,9 +938,7 @@ msgstr "Pencere önizlemesinin simge boyutu (px)"
 
 #: ui/BoxWindowPreviewOptions.ui.h:41
 msgid "If disabled, the previews icon size will be based on headerbar size"
-msgstr ""
-"Devre dışı bırakılırsa, önizleme simgesi boyutu başlık çubuğu boyutuna göre "
-"belirlenir"
+msgstr "Devre dışı bırakılırsa, önizleme simgesi boyutu başlık çubuğu boyutuna göre belirlenir"
 
 #: ui/BoxWindowPreviewOptions.ui.h:42
 msgid "Font size (px) of the preview titles"
@@ -1014,23 +994,21 @@ msgstr ""
 
 #: ui/SettingsAbout.ui.h:1
 msgid "Info"
-msgstr ""
+msgstr "Bilgi"
 
 #: ui/SettingsAbout.ui.h:2
-#, fuzzy
 msgid "Version"
-msgstr "sürüm: "
+msgstr "Sürüm: "
 
 #: ui/SettingsAbout.ui.h:3
 msgid "Source"
-msgstr ""
+msgstr "Kaynak"
 
 #: ui/SettingsAbout.ui.h:4
 msgid "GitHub"
 msgstr "GitHub"
 
 #: ui/SettingsAbout.ui.h:5
-#, fuzzy
 msgid "Export and Import"
 msgstr "Ayarları içeri ve dışarı aktar"
 
@@ -1077,7 +1055,6 @@ msgid "Toggle windows"
 msgstr "Pencereleri aç/kapat"
 
 #: ui/SettingsAction.ui.h:10
-#, fuzzy
 msgid "Scroll action"
 msgstr "Kaydırma simgesi eylemi"
 
@@ -1118,7 +1095,6 @@ msgid "Same as panel"
 msgstr "Panel ile aynı"
 
 #: ui/SettingsAction.ui.h:20
-#, fuzzy
 msgid "Hotkey overlay"
 msgstr "Numara yerleşimi"
 
@@ -1135,7 +1111,6 @@ msgstr ""
 "Shift ve Ctrl ile birlikte de kullanılabilir."
 
 #: ui/SettingsBehavior.ui.h:1
-#, fuzzy
 msgid "Applications"
 msgstr "Uygulamaların gruplama"
 
@@ -1172,7 +1147,6 @@ msgid "Show tooltip on hover"
 msgstr "Üzerine gelindiğinde araç ipucunu göster"
 
 #: ui/SettingsBehavior.ui.h:10
-#, fuzzy
 msgid "Isolate"
 msgstr "Ekranları ayır"
 
@@ -1186,7 +1160,7 @@ msgstr "Ekranları ayır"
 
 #: ui/SettingsBehavior.ui.h:13
 msgid "Overview"
-msgstr ""
+msgstr "Genel Bakış"
 
 #: ui/SettingsBehavior.ui.h:14
 msgid "Click empty space to close overview"
@@ -1198,57 +1172,45 @@ msgstr "Başlangıçta genel görünümü göstermeyi devre dışı bırak"
 
 #: ui/SettingsFineTune.ui.h:1
 msgid "Font size"
-msgstr ""
+msgstr "Yazı Tipi Boyutu"
 
 #: ui/SettingsFineTune.ui.h:2
 msgid "Tray Font Size"
-msgstr ""
+msgstr "Tepsi Yazı Tipi Boyutu"
 
 #: ui/SettingsFineTune.ui.h:3
-#, fuzzy
 msgid "(0 = theme default)"
-msgstr ""
-"Tepsi Yazı Tipi Boyutu\n"
-"(0 = tema varsayılanı)"
+msgstr "(0 = tema varsayılanı)"
+
 
 #: ui/SettingsFineTune.ui.h:4
-#, fuzzy
 msgid "LeftBox Font Size"
-msgstr ""
-"Sol Kutu Yazı Tipi Boyutu\n"
-"(0 = varsayılan)"
+msgstr "Sol Kutu Yazı Tipi Boyutu"
 
 #: ui/SettingsFineTune.ui.h:5
 msgid "Padding"
-msgstr ""
+msgstr "İç Boşluk"
 
 #: ui/SettingsFineTune.ui.h:6
-#, fuzzy
 msgid "Tray Item Padding"
-msgstr ""
-"Tepsi Öge Dolgusu\n"
-"(-1 = tema varsayılanı)"
+msgstr "Tepsi Öge Dolgusu"
+
 
 #: ui/SettingsFineTune.ui.h:7
-#, fuzzy
 msgid "(-1 = theme default)"
-msgstr ""
-"Sol Kutu Dolgusu\n"
-"(-1 = varsayılan)"
+msgstr "(-1 = varsayılan)"
+
 
 #: ui/SettingsFineTune.ui.h:8
-#, fuzzy
 msgid "Status Icon Padding"
-msgstr ""
-"Durum Simgesi Dolgusu\n"
-"(-1 = tema varsayılanı)"
+msgstr "Durum Simgesi Dolgusu"
+
 
 #: ui/SettingsFineTune.ui.h:9
 msgid "LeftBox Padding"
-msgstr ""
+msgstr "Sol Kutu İç Boşluğu"
 
 #: ui/SettingsFineTune.ui.h:10
-#, fuzzy
 msgid "Animate"
 msgstr "Animasyon türü"
 
@@ -1262,49 +1224,43 @@ msgstr "Açılan pencerelerde animasyon kullan"
 
 #: ui/SettingsFineTune.ui.h:13
 msgid "Gnome functionality"
-msgstr ""
+msgstr "Gnome işlevselliği"
 
 #: ui/SettingsFineTune.ui.h:14
-#, fuzzy
 msgid "Keep original gnome-shell dash"
-msgstr "Özgün gnome-shell rıhtımını koru (genel görünüm)"
+msgstr "Özgün gnome-shell rıhtımını koru"
 
 #: ui/SettingsFineTune.ui.h:15
 msgid "(overview)"
-msgstr ""
+msgstr "(genel görünüm)"
 
 #: ui/SettingsFineTune.ui.h:16
 msgid "Keep original gnome-shell top panel"
 msgstr "Özgün gnome-shell üst panelini koru"
 
 #: ui/SettingsFineTune.ui.h:17
-#, fuzzy
 msgid "Activate panel menu buttons on click only"
-msgstr ""
-"Sadece tıklandığında panel menü düğmelerini (ör. tarih menüsü) etkinleştir"
+msgstr "Sadece tıklandığında panel menü düğmelerini etkinleştir"
 
 #: ui/SettingsFineTune.ui.h:18
-#, fuzzy
 msgid "(e.g. date menu)"
-msgstr "Tarih menüsü"
+msgstr "(Örn. tarih menüsü)"
 
 #: ui/SettingsFineTune.ui.h:19
 msgid "Force Activities hot corner on primary monitor"
 msgstr "Birincil ekranda Etkinlikler sıcak köşesini zorla"
 
 #: ui/SettingsFineTune.ui.h:20
-#, fuzzy
 msgid "App icon secondary menu"
 msgstr "Uygulama simgesi ikincil (sağ tık) menüsü"
 
 #: ui/SettingsFineTune.ui.h:21
-#, fuzzy
 msgid "(right-click menu)"
-msgstr "Uygulama simgesi ikincil (sağ tık) menüsü"
+msgstr "(sağ tık menüsü)"
 
 #: ui/SettingsPosition.ui.h:1
 msgid "Panel"
-msgstr ""
+msgstr "Panel"
 
 #: ui/SettingsPosition.ui.h:2
 msgid "Display the main panel on"
@@ -1323,14 +1279,12 @@ msgid "Hide and reveal the panel according to preferences"
 msgstr "Paneli tercihlere göre gizle ve göster"
 
 #: ui/SettingsPosition.ui.h:6
-#, fuzzy
 msgid "Order and Position on monitors"
 msgstr "Ekrandaki sıra ve konumlar"
 
 #: ui/SettingsPosition.ui.h:7
-#, fuzzy
 msgid "Monitor"
-msgstr "Ekran "
+msgstr "Ekran"
 
 #: ui/SettingsPosition.ui.h:8
 msgid "Apply changes to all monitors"
@@ -1341,32 +1295,20 @@ msgid "Panel screen position"
 msgstr "Panelin ekrandaki konumu"
 
 #: ui/SettingsPosition.ui.h:14
-#, fuzzy
 msgid "Panel thickness"
-msgstr ""
-"Panel kalınlığı\n"
-"(varsayılan 48)"
+msgstr "Panel kalınlığı"
 
 #: ui/SettingsPosition.ui.h:15
-#, fuzzy
 msgid "(default is 48)"
-msgstr ""
-"Panel kalınlığı\n"
-"(varsayılan 48)"
+msgstr "(varsayılan 48)"
 
 #: ui/SettingsPosition.ui.h:17
-#, fuzzy, no-c-format
 msgid "Panel length (%)"
-msgstr ""
-"Panel uzunluğu (%)\n"
-"(varsayılan 100)"
+msgstr "Panel uzunluğu (%)"
 
 #: ui/SettingsPosition.ui.h:18
-#, fuzzy
 msgid "(default is 100)"
-msgstr ""
-"Panel uzunluğu (%)\n"
-"(varsayılan 100)"
+msgstr "(varsayılan 100)"
 
 # Çapala diye de çevirebilirdik fakat daha net anlaşılması için sabitle diye tercih ettim. 
 #: ui/SettingsPosition.ui.h:19
@@ -1374,50 +1316,36 @@ msgid "Anchor"
 msgstr "Sabitle"
 
 #: ui/SettingsPosition.ui.h:23
-#, fuzzy
 msgid "Taskbar Display"
 msgstr "Görev çubuğu"
 
 #: ui/SettingsStyle.ui.h:1
 msgid "AppIcon style"
-msgstr ""
+msgstr "Uygulama Simge Tarzı"
 
 #: ui/SettingsStyle.ui.h:2
-#, fuzzy
 msgid "App Icon Margin"
-msgstr ""
-"Uygulama Simge Marjı\n"
-"(varsayılan 8)"
+msgstr "Uygulama Simge Marjı"
 
 #: ui/SettingsStyle.ui.h:3
-#, fuzzy
 msgid "(default is 8)"
-msgstr ""
-"Uygulama Simge Marjı\n"
-"(varsayılan 8)"
+msgstr "(varsayılan 8)"
 
 #: ui/SettingsStyle.ui.h:4
-#, fuzzy
 msgid "App Icon Padding"
-msgstr ""
-"Uygulama Simge Dolgusu\n"
-"(varsayılan 4)"
+msgstr "Uygulama Simge Dolgusu"
 
 #: ui/SettingsStyle.ui.h:5
-#, fuzzy
 msgid "(default is 4)"
-msgstr ""
-"Uygulama Simge Dolgusu\n"
-"(varsayılan 4)"
+msgstr "(varsayılan 4)"
 
 #: ui/SettingsStyle.ui.h:6
 msgid "Animate hovering app icons"
 msgstr "Uygulama simgelerinin üzerine gelişleri canlandır"
 
 #: ui/SettingsStyle.ui.h:7
-#, fuzzy
 msgid "Running indicator"
-msgstr "Çalışan gösterge konumu"
+msgstr "Çalışan gösterge"
 
 #: ui/SettingsStyle.ui.h:8
 msgid "Running indicator position"
@@ -1460,21 +1388,18 @@ msgid "Running indicator style (Unfocused apps)"
 msgstr "Çalışan gösterge biçimi (Odaklanmamış uygulamalar)"
 
 #: ui/SettingsStyle.ui.h:22
-#, fuzzy
 msgid "Panel style"
-msgstr "Paneli Akıllı Gizle"
+msgstr "Panel tarzı"
 
 #: ui/SettingsStyle.ui.h:23
-#, fuzzy
 msgid "Override panel theme background color"
-msgstr "Panel tema arka plan rengini geçersiz kıl "
+msgstr "Panel tema arka plan renginin üzerine yaz"
 
 #: ui/SettingsStyle.ui.h:24
 msgid "Override panel theme background opacity"
-msgstr "Panel tema arka plan saydamlığını geçersiz kıl"
+msgstr "Panel tema arka plan saydamlığını üzerine yaz"
 
 #: ui/SettingsStyle.ui.h:26
-#, no-c-format
 msgid "Panel background opacity (%)"
 msgstr "Panel arka plan matlığı (%)"
 
@@ -1487,51 +1412,46 @@ msgid "Change opacity when a window gets close to the panel"
 msgstr "Bir pencere panele yaklaştığında matlığı değişir"
 
 #: ui/SettingsStyle.ui.h:30
-#, fuzzy
 msgid "Override panel theme gradient"
 msgstr "Panel tema renk geçişini geçersiz kıl"
 
 #: ui/SettingsStyle.ui.h:32
-#, no-c-format
 msgid "Gradient top color and opacity (%)"
 msgstr "Renk geçişi üst renk ve matlık (%)"
 
 #: ui/SettingsStyle.ui.h:34
-#, no-c-format
 msgid "Gradient bottom color and opacity (%)"
 msgstr "Renk geçişi alt renk ve matlık (%)"
 
-#~ msgid "Current Show Applications icon"
-#~ msgstr "Mevcut Uygulamaları Göster simgesi"
+msgid "Current Show Applications icon"
+msgstr "Mevcut Uygulamaları Göster simgesi"
 
-#~ msgid "Custom Show Applications image icon"
-#~ msgstr "Özel Uygulamaları Göster simgesi resmi"
+msgid "Custom Show Applications image icon"
+msgstr "Özel Uygulamaları Göster simgesi resmi"
 
-#~ msgid "Position"
-#~ msgstr "Konum"
+msgid "Position"
+msgstr "Konum"
 
-#~ msgid "Style"
-#~ msgstr "Biçim"
+msgid "Style"
+msgstr "Biçim"
 
-#~ msgid "Top Bar > Show App Menu must be enabled in Tweak Tool"
-#~ msgstr ""
-#~ "İnce Ayarlar uygulamasından Tepe Çubuğu > Uygulama Menüsü Göster "
-#~ "etkinleştirilmelidir"
+msgid "Top Bar > Show App Menu must be enabled in Tweak Tool"
+msgstr "İnce Ayarlar uygulamasından Tepe Çubuğu > Uygulama Menüsü Göster "
 
-#~ msgid "Behavior"
-#~ msgstr "Davranış"
+msgid "Behavior"
+msgstr "Davranış"
 
-#~ msgid "Action"
-#~ msgstr "Eylem"
+msgid "Action"
+msgstr "Eylem"
 
-#~ msgid "Fine-Tune"
-#~ msgstr "İnce Ayarlar"
+msgid "Fine-Tune"
+msgstr "İnce Ayarlar"
 
-#~ msgid "About"
-#~ msgstr "Hakkında"
+msgid "About"
+msgstr "Hakkında"
 
-#~ msgid "Top Bar"
-#~ msgstr "Tepe Çubuğu"
+msgid "Top Bar"
+msgstr "Tepe Çubuğu"
 
-#~ msgid "Move to current Workspace"
-#~ msgstr "Geçerli Çalışma Alanına taşı"
+msgid "Move to current Workspace"
+msgstr "Geçerli Çalışma Alanına taşı"

--- a/ui/SettingsAbout.ui
+++ b/ui/SettingsAbout.ui
@@ -3,7 +3,7 @@
   <requires lib="gtk" version="4.0"/>
 
   <object class="AdwPreferencesPage" id="about">
-    <property name="title">About</property>
+    <property translatable="yes" name="title">About</property>
     <property name="icon_name">help-about-symbolic</property>
 
       <!-- group info -->

--- a/ui/SettingsAction.ui
+++ b/ui/SettingsAction.ui
@@ -3,7 +3,7 @@
   <requires lib="gtk" version="4.0"/>
 
   <object class="AdwPreferencesPage" id="action">
-    <property name="title">Action</property>
+    <property translatable="yes" name="title">Action</property>
     <property name="icon_name">view-pin-symbolic</property>
 
     <!-- group click action -->

--- a/ui/SettingsBehavior.ui
+++ b/ui/SettingsBehavior.ui
@@ -2,7 +2,7 @@
 <interface>
   <requires lib="gtk" version="4.0"/>
   <object class="AdwPreferencesPage" id="behavior">
-    <property name="title">Behavior</property>
+    <property translatable="yes" name="title">Behavior</property>
     <property name="icon_name">preferences-system-symbolic</property>
 
     <!-- group applications -->

--- a/ui/SettingsFineTune.ui
+++ b/ui/SettingsFineTune.ui
@@ -38,7 +38,7 @@
   </object>
 
   <object class="AdwPreferencesPage" id="finetune">
-    <property name="title">Fine-Tune</property>
+    <property translatable="yes" name="title">Fine-Tune</property>
     <property name="icon_name">preferences-other-symbolic</property>
 
       <!-- group font -->

--- a/ui/SettingsPosition.ui
+++ b/ui/SettingsPosition.ui
@@ -16,7 +16,7 @@
   </object>
 
   <object class="AdwPreferencesPage" id="position">
-    <property name="title">Position</property>
+    <property translatable="yes" name="title">Position</property>
     <property name="icon_name">find-location-symbolic</property>
 
       <!-- group panel -->

--- a/ui/SettingsStyle.ui
+++ b/ui/SettingsStyle.ui
@@ -35,7 +35,7 @@
   </object>
 
   <object class="AdwPreferencesPage" id="style">
-    <property name="title">Style</property>
+    <property translatable="yes" name="title">Style</property>
     <property name="icon_name">applications-graphics-symbolic</property>
 
     <!-- group app icon style -->


### PR DESCRIPTION
- Turkish translation updated.
- In `ui` files, page titles are not translated in my current system. added `translatable="yes"` to every page title
System: Arch Linux Gnome
Language: Turkish