### PR TITLE
Fix german translation for "Device Management"

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -278,7 +278,7 @@ msgstr "System"
 
 #: appIcons.js:1801
 msgid "Device Management"
-msgstr "Laufwerksverwaltung"
+msgstr "Geräteverwaltung"
 
 #: appIcons.js:1806
 msgid "Disk Management"


### PR DESCRIPTION
"Device management" had the same german translation as "Disk Management" (directly below). Probably a copy-and-paste error.

The message is still a bit unfortunate, because this menu entry actually opens the "**display** management" settings, but the same is true for the original english message (and probably the other translations as well, but I wouldn't know).