### PR TITLE
Fix crash on doubletapping close button in window preview

### DIFF
--- a/windowPreview.js
+++ b/windowPreview.js
@@ -877,6 +877,7 @@ export const Preview = GObject.registerClass({
     }
 
     _onCloseBtnClick() {
+        if(!this.reactive) return;
         this._hideOrShowCloseButton(true);
         this.reactive = false;
 


### PR DESCRIPTION
#1968 
By checking if the component is active before killing the process we can prevent a crash