### PR TITLE
Update style for GNOME 46

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -27,44 +27,32 @@
 	padding: 0; 
 }
 
-#dashtopanelScrollview .app-well-app .overview-icon,
-.dashtopanelMainPanel .show-apps .overview-icon {
+#dashtopanelScrollview .overview-tile,
+.dashtopanelMainPanel .overview-tile {
 	background: none;
-	border: none;
-	margin: 0;
-	padding: 0;
 }
 
-#dashtopanelScrollview .app-well-app .overview-label {
+#dashtopanelScrollview .overview-tile .overview-label {
 	/* must match TITLE_RIGHT_PADDING in apppicons.js */
 	padding-right: 8px;
+	text-align: left;
 }
 
-#dashtopanelScrollview .app-well-app:hover .overview-icon,
-#dashtopanelScrollview .app-well-app:focus .overview-icon {
-	background: none;
-}
-
-.dashtopanelMainPanel .show-apps:hover .overview-icon,
-#dashtopanelScrollview .app-well-app:hover .dtp-container,
-#dashtopanelScrollview .app-well-app:focus .dtp-container {
+#dashtopanelScrollview .overview-tile:hover .dtp-container,
+#dashtopanelScrollview .overview-tile:focus .dtp-container {
 	background-color: rgba(238, 238, 236, 0.1);
 }
 
-#dashtopanelScrollview .app-well-app:hover .dtp-container.animate-appicon-hover {
+#dashtopanelScrollview .overview-tile:hover .dtp-container.animate-appicon-hover {
 	background: none;
 }
 
-#dashtopanelScrollview .app-well-app:active .dtp-container {
+#dashtopanelScrollview .overview-tile:active .dtp-container {
 	background-color: rgba(238, 238, 236, 0.18);
 }
 
-#dashtopanelScrollview .app-well-app .favorite {
+#dashtopanelScrollview .overview-tile .favorite {
 	background-color: rgba(80, 150, 255, 0.4);
-}
-
-#dashtopanelScrollview .app-well-app-running-dot {
-	margin-bottom: 0;
 }
 
 #dashtopanelTaskbar .scrollview-fade {


### PR DESCRIPTION
The app-well-app class is no longer available. Use overview-tile class instead, and update some styles to match with earlier GNOME Shell versions.