### PR TITLE
Replace gnome-terminal command with kgx

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1784,8 +1784,8 @@ export const MyShowAppsIconMenu = class extends PopupMenu.PopupMenu {
         }
 
         this._appendItem({
-            title: _('Terminal'),
-            cmd: ['gnome-terminal']
+            title: _('Console'),
+            cmd: ['kgx']
         });
 
         this._appendItem({


### PR DESCRIPTION
The default terminal emulator of GNOME has been changed from gnome-terminal to console in version 42.0: https://gitlab.gnome.org/GNOME/gnome-build-meta/-/commit/307478d65112c7b63946b6eb61c441f139f40942