### PR TITLE
Fix build failure (after PR #2006)

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -1231,7 +1231,7 @@ msgstr "Attiva i pulsanti del menu del pannello solo con un clic"
 
 #: ui/SettingsFineTune.ui.h:18
 msgid "(e.g. date menu)"
-msgstr (es. menu data)"
+msgstr "(es. menu data)"
 
 #: ui/SettingsFineTune.ui.h:19
 msgid "Force Activities hot corner on primary monitor"


### PR DESCRIPTION
"make" can't complete due to the missing quote symbol in the msgstr

```
msgfmt -c po/it.po -o po/it.mo
po/it.po:1234:9: syntax error
po/it.po:1234: keyword "es" unknown
po/it.po:1235: end-of-line within string
msgfmt: found 3 fatal errors
make: *** [Makefile:66: po/it.mo] Error 1
```
