### PR TITLE
remove icon background (hover and active)

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -149,7 +149,7 @@ export const TaskbarAppIcon = GObject.registerClass({
         
         this._container = new St.Widget({ style_class: 'dtp-container', layout_manager: new Clutter.BinLayout() });
         this._dotsContainer = new St.Widget({ layout_manager: new Clutter.BinLayout() });
-        this._dtpIconContainer = new St.Widget({ layout_manager: new Clutter.BinLayout(), style: getIconContainerStyle(panel.checkIfVertical()) });
+        this._dtpIconContainer = new St.Widget({ name: 'dashtopanelAppIcon', layout_manager: new Clutter.BinLayout(), style: getIconContainerStyle(panel.checkIfVertical()) });
 
         this.remove_child(this._iconContainer);
         

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -147,3 +147,7 @@
 .symbolic-icon-style {
     -st-icon-style: symbolic;
 }
+
+#dashtopanelAppIcon .overview-icon {
+	background: none;
+}


### PR DESCRIPTION
#2081 remove hover and active icon background added in gnome 46