### PR TITLE
Update desktopIconsIntegration to the last version

### DIFF
--- a/desktopIconsIntegration.js
+++ b/desktopIconsIntegration.js
@@ -57,15 +57,20 @@
 
 import GLib from 'gi://GLib';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-
-import {EXTENSION_UUID} from './extension.js';
-
 import * as ExtensionUtils from 'resource:///org/gnome/shell/misc/extensionUtils.js';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 const IDENTIFIER_UUID = "130cbc66-235c-4bd6-8571-98d2d8bba5e2";
 
-export const DesktopIconsUsableAreaClass = class {
+export class DesktopIconsUsableAreaClass {
+    _checkIfExtensionIsEnabled(extension) {
+        return (extension?.state === ExtensionUtils.ExtensionState.ENABLED) ||
+               (extension?.state === ExtensionUtils.ExtensionState.ACTIVE);
+    }
+
     constructor() {
+        const Me = Extension.lookupByURL(import.meta.url);
+        this._UUID = Me.uuid;
         this._extensionManager = Main.extensionManager;
         this._timedMarginsID = 0;
         this._margins = {};
@@ -74,7 +79,7 @@ export const DesktopIconsUsableAreaClass = class {
                 return;
 
             // If an extension is being enabled and lacks the DesktopIconsUsableArea object, we can avoid launching a refresh
-            if (extension.state === ExtensionUtils.ExtensionState.ENABLED) {
+            if (this._checkIfExtensionIsEnabled(extension)) {
                 this._sendMarginsToExtension(extension);
                 return;
             }
@@ -150,11 +155,11 @@ export const DesktopIconsUsableAreaClass = class {
     _sendMarginsToExtension(extension) {
         // check that the extension is an extension that has the logic to accept
         // working margins
-        if (extension?.state !== ExtensionUtils.ExtensionState.ENABLED)
+        if (!this._checkIfExtensionIsEnabled(extension))
             return;
 
         const usableArea = extension?.stateObj?.DesktopIconsUsableArea;
-         if (usableArea?.uuid === IDENTIFIER_UUID)
-            usableArea.setMarginsForExtension(EXTENSION_UUID, this._margins);
+        if (usableArea?.uuid === IDENTIFIER_UUID)
+            usableArea.setMarginsForExtension(this._UUID, this._margins);
     }
 }


### PR DESCRIPTION
These changes remove some dependencies, and ensure that it works on Gnome46, where there is a change in the ExtensionState names.