### PR TITLE
Destroy panel barriers on shutdown

### DIFF
--- a/panelManager.js
+++ b/panelManager.js
@@ -59,6 +59,14 @@ export const PanelManager = class {
         this._injectionManager = new InjectionManager();
 
         this._saveMonitors();
+
+        global.connect('shutdown', () => {
+            if (this.allPanels) {
+                this.allPanels.forEach(p => {
+                    this._removePanelBarriers(p);
+                });
+            }
+        });
     }
 
     enable(reset) {


### PR DESCRIPTION
It was being leaked, which is detected on mutter shutdown and caused SIGABRT in the Xorg session.

See related issue and fix:
https://gitlab.gnome.org/GNOME/mutter/-/issues/3011
https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2975