### PR TITLE
Fix display of Extensions in context menu. Allow to use custom System…

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1807,8 +1807,8 @@ export const MyShowAppsIconMenu = class extends PopupMenu.PopupMenu {
         });
 
         this._appendItem({
-            title: _('System monitor'),
-            cmd: ['gnome-system-monitor']
+            title: _(SETTINGS.get_string('contextmenu-sysmon-title')),
+            cmd: [SETTINGS.get_string('contextmenu-sysmon-cmd')]
         });
 
         this._appendItem({
@@ -1818,7 +1818,7 @@ export const MyShowAppsIconMenu = class extends PopupMenu.PopupMenu {
 
         this._appendItem({
             title: _('Extensions'),
-            cmd: ['gnome-shell-extension-prefs']
+            cmd: ['gnome-extensions-app']
         });
 
         this._appendItem({

--- a/prefs.js
+++ b/prefs.js
@@ -2080,6 +2080,16 @@ const Preferences = class {
                             'active',
                             Gio.SettingsBindFlags.DEFAULT);
 
+        this._settings.bind('contextmenu-sysmon-title',
+                            this._builder.get_object('sysmon_title_entry'),
+                            'text',
+                            Gio.SettingsBindFlags.DEFAULT);
+
+        this._settings.bind('contextmenu-sysmon-cmd',
+                            this._builder.get_object('sysmon_cmd_entry'),
+                            'text',
+                            Gio.SettingsBindFlags.DEFAULT);
+
         // About Panel
 
         this._builder.get_object('extension_version').set_label(this._metadata.version.toString() + (this._metadata.commit ? ' (' + this._metadata.commit + ')' : ''));

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -795,6 +795,14 @@
       <default>{'SIMPLE':1,'RIPPLE':1.25,'PLANK':2}</default>
       <summary>App icon hover animation zoom scale in relation to the app icon size</summary>
     </key>
+    <key type="s" name="contextmenu-sysmon-title">
+      <default>"System monitor"</default>
+      <summary>Context menu system monitor titile</summary>
+    </key>
+    <key type="s" name="contextmenu-sysmon-cmd">
+      <default>"gnome-system-monitor"</default>
+      <summary>Context menu system monitor command</summary>
+    </key>
     <key type="b" name="secondarymenu-contains-appmenu">
       <default>true</default>
       <summary>Integrate items from the gnome appmenu into the right click menu</summary>

--- a/ui/SettingsFineTune.ui
+++ b/ui/SettingsFineTune.ui
@@ -231,6 +231,34 @@
         </object>
       </child>
 
+      <!-- group context menu -->
+      <child>
+        <object class="AdwPreferencesGroup" id="finetune_group_context_menu">
+          <property name="title" translatable="yes">Context Menu</property>
+
+          <child>
+            <object class="AdwExpanderRow">
+              <property name="title" bind-source="sysmon_title_entry" bind-property="text" bind-flags="sync-create"></property>
+              <property name="subtitle" bind-source="sysmon_cmd_entry" bind-property="text" bind-flags="sync-create"></property>
+
+              <child>
+                <object class="AdwEntryRow" id="sysmon_title_entry">
+                  <property name="title" translatable="yes">Title</property>
+                </object>
+              </child>
+
+              <child>
+                <object class="AdwEntryRow" id="sysmon_cmd_entry">
+                  <property name="title" translatable="yes">Command</property>
+                </object>
+              </child>
+
+            </object>
+          </child>
+
+        </object>
+      </child>
+
       <!-- group panel -->
       <child>
         <object class="AdwPreferencesGroup" id="finetune_group_">


### PR DESCRIPTION
… monitor.

https://github.com/user-attachments/assets/9231633b-7e61-454a-915e-ac6e0526bf87

By the way, for those who use `Console` instead of `Gnome Terminal`, to make the `Terminal` item appear you need to run these commands:
```
gsettings set org.gnome.desktop.default-applications.terminal exec kgx
gsettings set org.gnome.desktop.default-applications.terminal exec-arg -e
```

<details>

<summary>previous variant</summary>

https://github.com/user-attachments/assets/e8d1297c-15b5-4294-964b-69171e4799d3

</details>
