### PR TITLE
Draft of app switching based on the taskbar order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 UUID = dash-to-panel@jderose9.github.com
 BASE_MODULES = extension.js stylesheet.css metadata.json COPYING README.md
-EXTRA_MODULES = appIcons.js panel.js panelManager.js proximity.js intellihide.js progress.js panelPositions.js panelSettings.js panelStyle.js overview.js taskbar.js transparency.js windowPreview.js prefs.js utils.js desktopIconsIntegration.js
+EXTRA_MODULES = appIcons.js panel.js panelManager.js proximity.js intellihide.js progress.js panelPositions.js panelSettings.js panelStyle.js overview.js taskbar.js transparency.js windowPreview.js prefs.js utils.js desktopIconsIntegration.js linearSwitcher.js
 UI_MODULES = ui/BoxAdvancedOptions.ui ui/BoxAnimateAppIconHoverOptions.ui ui/BoxDotOptions.ui ui/BoxDynamicOpacityOptions.ui ui/BoxGroupAppsOptions.ui ui/BoxIntellihideOptions.ui ui/BoxMiddleClickOptions.ui ui/BoxOverlayShortcut.ui ui/BoxScrollIconOptions.ui ui/BoxScrollPanelOptions.ui ui/BoxSecondaryMenuOptions.ui ui/BoxShowApplicationsOptions.ui ui/BoxShowDesktopOptions.ui ui/BoxWindowPreviewOptions.ui ui/SettingsAbout.ui ui/SettingsAction.ui ui/SettingsBehavior.ui ui/SettingsFineTune.ui ui/SettingsPosition.ui ui/SettingsStyle.ui
 
 EXTRA_IMAGES = highlight_stacked_bg.svg highlight_stacked_bg_2.svg highlight_stacked_bg_3.svg

--- a/appIcons.js
+++ b/appIcons.js
@@ -801,6 +801,14 @@ export const TaskbarAppIcon = GObject.registerClass({
         return false;
     }
 
+    isRunning() {
+        let appCount = this.getAppIconInterestingWindows().length;
+
+        // We check if the app is running, and that the # of windows is > 0 in
+        // case we use workspace isolation,
+        return this.app.state == Shell.AppState.RUNNING && appCount > 0;
+    }
+
     _isWideDotStyle(dotStyle) {
         return dotStyle == DOT_STYLE.SEGMENTED || 
             dotStyle == DOT_STYLE.CILIORA || 

--- a/linearSwitcher.js
+++ b/linearSwitcher.js
@@ -1,0 +1,78 @@
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
+import Meta from 'gi://Meta';
+import Shell from 'gi://Shell';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Utils from './utils.js';
+
+import {SETTINGS} from './extension.js';
+
+export const LinearSwitcher = class {
+    constructor() {
+        
+    }
+
+    enable (primaryPanel) {
+        this._panel = primaryPanel;
+        this.taskbar = primaryPanel.taskbar;
+
+        this._addKeybindings();
+    }
+
+    disable() {
+        this._removeKeybindings();
+    }
+    
+    _addKeybindings() {
+        Utils.addKeybinding('app-hotkey-switch-left', SETTINGS, () => this._switchWindow(-1));
+        Utils.addKeybinding('app-hotkey-switch-right', SETTINGS, () => this._switchWindow(1));
+    }
+
+    _removeKeybindings() {
+        Utils.removeKeybinding('app-hotkey-switch-left');
+        Utils.removeKeybinding('app-hotkey-switch-right');
+    }
+
+    _switchWindow(direction) {
+        let is = [];
+        let tracker = Shell.WindowTracker.get_default();
+
+        log(tracker.focus_app.id);
+
+        let currentFocusIndex = 0;
+        
+        let appIcons = this.taskbar._getAppIcons();
+
+        if(appIcons.length > 1){
+            for(let i in appIcons) {
+                if(appIcons[i]._isFocusedWindow()) {
+                    currentFocusIndex = i;
+                }
+                
+                if(appIcons[i].isRunning()) {
+                    is.push(i);
+                }
+                // apps.push(appIcons[i]);
+            }
+
+            let currentIndexI = is.indexOf(currentFocusIndex);
+
+            let newIndexI = currentIndexI+direction;
+    
+            if(newIndexI < 0) {
+                newIndexI = is.length-1;
+            }
+
+            if(newIndexI > is.length-1) {
+                newIndexI = 0;
+            }
+            
+            let newI = is[newIndexI];
+
+            let prefixModifiers = Clutter.ModifierType.SUPER_MASK
+    
+            let button = 1;
+            appIcons[newI].activate(button, prefixModifiers, !this.taskbar.allowSplitApps);
+        }
+    }
+};

--- a/panelManager.js
+++ b/panelManager.js
@@ -28,6 +28,7 @@
  */
 
 import * as Overview from './overview.js';
+import * as LinearSwitcher from './linearSwitcher.js';
 import * as Panel from './panel.js';
 import * as PanelSettings from './panelSettings.js';
 import * as Proximity from './proximity.js';
@@ -55,6 +56,8 @@ export const PanelManager = class {
 
     constructor() {
         this.overview = new Overview.Overview();
+        this.linearSwitching = new LinearSwitcher.LinearSwitcher();
+        
         this.panelsElementPositions = {};
         this._injectionManager = new InjectionManager();
 
@@ -72,6 +75,7 @@ export const PanelManager = class {
             this.primaryPanel = this._createPanel(this.dtpPrimaryMonitor, SETTINGS.get_boolean('stockgs-keep-top-panel'));
             this.allPanels.push(this.primaryPanel);
             this.overview.enable(this.primaryPanel);
+            this.linearSwitching.enable(this.primaryPanel);
 
             this.setFocusedMonitor(this.dtpPrimaryMonitor);
         }
@@ -219,6 +223,7 @@ export const PanelManager = class {
 
     disable(reset) {
         this.primaryPanel && this.overview.disable();
+        this.linearSwitching.disable();
         this.proximityManager.destroy();
 
         this.allPanels.forEach(p => {

--- a/prefs.js
+++ b/prefs.js
@@ -1872,6 +1872,19 @@ const Preferences = class {
                             'text',
                             Gio.SettingsBindFlags.DEFAULT);
         this._settings.connect('changed::shortcut-text', () => {setShortcut(this._settings, 'shortcut');});
+        
+        // Settings for the linear window switching
+        this._settings.bind('app-hotkey-switch-left-text',
+            this._builder.get_object('app-hotkey-switch-left-entry'),
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.connect('changed::app-hotkey-switch-left-text', () => {setShortcut(this._settings, 'app-hotkey-switch-left');});
+
+        this._settings.bind('app-hotkey-switch-right-text',
+            this._builder.get_object('app-hotkey-switch-right-entry'),
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.connect('changed::app-hotkey-switch-right-text', () => {setShortcut(this._settings, 'app-hotkey-switch-right');});
 
         // Create dialog for number overlay options
         this._builder.get_object('overlay_button').connect('clicked', () => {

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -1268,6 +1268,30 @@
         Keybinding to either show or launch the 10th application in the dash.
       </description>
     </key>
+    <key type="s" name="app-hotkey-switch-left-text">
+      <default>"&lt;Super&gt;h"</default>
+      <summary>Keybinding to show the dock and the number overlay.</summary>
+      <description>Behavior depends on hotkeys-show-dock and hotkeys-overlay.</description>
+    </key>
+    <key name="app-hotkey-switch-left" type="as">
+      <default><![CDATA[['<Super>h']]]></default>
+      <summary>Keybinding to switch to the window on the left</summary>
+      <description>
+        Keybinding to switch the window on the left. If the current window is leftmost, it will cycle to the rightmost window.
+      </description>
+    </key>
+    <key type="s" name="app-hotkey-switch-right-text">
+      <default>"&lt;Super&gt;l"</default>
+      <summary>Keybinding to show the dock and the number overlay.</summary>
+      <description>Behavior depends on hotkeys-show-dock and hotkeys-overlay.</description>
+    </key>
+    <key name="app-hotkey-switch-right" type="as">
+      <default><![CDATA[['<Super>l']]]></default>
+      <summary>Keybinding to switch to the window on the right</summary>
+      <description>
+        Keybinding to switch the window on the right. If the current window is rightmost, it will cycle to the leftmost window.
+      </description>
+    </key>
      <key type="b" name="progress-show-bar">
       <default>true</default>
       <summary>Show progress bar on app icon</summary>

--- a/ui/SettingsAction.ui
+++ b/ui/SettingsAction.ui
@@ -161,5 +161,41 @@
       </object>
     </child>
 
+    <!-- switch left and right hotkeys -->
+    <child>
+      <object class="AdwPreferencesGroup" id="action_group_linear_switching">
+        <property name="title" translatable="yes">Linear window switching hotkeys</property>
+
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Shortcut to switch to the window on the left</property>
+            <property name="subtitle" translatable="yes">Syntax: &amp;lt;Shift&amp;gt;, &amp;lt;Ctrl&amp;gt;, &amp;lt;Alt&amp;gt;, &amp;lt;Super&amp;gt;</property>
+            <child>
+              <object class="GtkEntry" id="app-hotkey-switch-left-entry">
+                <property name="valign">center</property>
+                <property name="width_chars">12</property>
+                <property name="placeholder_text" translatable="yes">e.g. &lt;Super&gt;h</property>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Shortcut to switch to the window on the right</property>
+            <property name="subtitle" translatable="yes">Syntax: &amp;lt;Shift&amp;gt;, &amp;lt;Ctrl&amp;gt;, &amp;lt;Alt&amp;gt;, &amp;lt;Super&amp;gt;</property>
+            <child>
+              <object class="GtkEntry" id="app-hotkey-switch-right-entry">
+                <property name="valign">center</property>
+                <property name="width_chars">12</property>
+                <property name="placeholder_text" translatable="yes">e.g. &lt;Super&gt;l</property>
+              </object>
+            </child>
+          </object>
+        </child>
+
+      </object>
+    </child>
+
   </object>
 </interface>


### PR DESCRIPTION
Hi,

I am trying to draft a solution for https://github.com/home-sweet-gnome/dash-to-panel/issues/2163

It is at a very early stage and I unfortunately have an issue so I was wondering if I could ask for a little bit of help because the logic of the process is lost to me. I have ungrouped windows, so every window is a separate entry in the taskbar. The code that I have written works without issues on windows of differents apps, so for example if I have open `Firefox, Terminal, File manager, Sublime Text` then if would switch back and forth correctly, no issues there. However, if I have several windows of the same app, for example, `Terminal w1, Terminal w2, Terminal w3` it would sometimes jump between windows in a wrong order, for example if I click left from `w3` it would sometimes switch to `w1` instead of `w2`.

The main logic is in linearSwitcher.js

Thank you for the help!