### PR TITLE
Update command for Extensions app

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1818,7 +1818,7 @@ export const MyShowAppsIconMenu = class extends PopupMenu.PopupMenu {
 
         this._appendItem({
             title: _('Extensions'),
-            cmd: ['gnome-shell-extension-prefs']
+            cmd: ['gnome-extensions-app']
         });
 
         this._appendItem({


### PR DESCRIPTION
The old command was removed from GNOME 47:
https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3456