### PR TITLE
Add Spanish translations for "Quit Window" and "Quit Windows"

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -255,6 +255,12 @@ msgstr "Importar configuraciones"
 msgid "Quit"
 msgstr "Salir"
 
+#: appIcons.js:1497
+msgid "Quit %d Window"
+msgid_plural "Quit %d Windows"
+msgstr[0] "Cerrar %d ventana"
+msgstr[1] "Cerrar %d ventanas"
+
 #: appIcons.js:1515
 msgid "Windows"
 msgstr "Ventanas"


### PR DESCRIPTION
**Descripción:**
Este Pull Request incluye mejoras y correcciones en las traducciones al español de la extensión Dash to Panel. Los cambios fueron realizados directamente en el archivo es.po y luego se generó el archivo es.mo correspondiente para que la extensión funcione correctamente en el sistema.

***Cambios realizados:***
Traducción de la cadena con pluralidad "Quit %d Window(s)" para manejar adecuadamente el conteo de ventanas. Ahora se traduce como "Cerrar %d ventana(s)".

***Motivo de los cambios:***
El propósito de estas mejoras es asegurar que todas las cadenas del menú y opciones de Dash to Panel sean claras y correctas en español, especialmente en las situaciones con pluralidad de ventanas.

**Pruebas realizadas:**
Verifiqué que la extensión se muestra correctamente en español después de aplicar las traducciones.
Probé que las cadenas relacionadas con el menú de "Cerrar" se actualizan correctamente dependiendo del número de ventanas abiertas.

**Capturas de pantalla:**

![Captura desde 2025-01-02 11-19-39](https://github.com/user-attachments/assets/00526c28-bb0f-4d9b-bcf3-7da982fc5c3b)

![Captura desde 2025-01-02 11-46-27](https://github.com/user-attachments/assets/91417820-5fc5-4bd3-81a2-c6e8c1281e30)

**Notas adicionales:**
No he realizado cambios en el código fuente de la extensión, solo en las cadenas de traducción.
El archivo es.mo está listo para ser colocado en el directorio de traducciones de la extensión.
