### PR TITLE
Makefile: Fix potfile generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MODULES = src/*.js src/stylesheet.css metadata.json COPYING README.md
 UI_MODULES = ui/*.ui
 IMAGES = ./* ../media/design/svg/dash-to-panel-logo-light.svg
 
-TOLOCALIZE =  prefs.js appIcons.js taskbar.js
+TOLOCALIZE =  src/prefs.js src/appIcons.js src/taskbar.js
 MSGSRC = $(wildcard po/*.po)
 ifeq ($(strip $(DESTDIR)),)
 	INSTALLBASE = $(HOME)/.local/share/gnome-shell/extensions


### PR DESCRIPTION
Sets the correct paths to JS files, as previously `make potfile` failed with error.

> make: *** No rule to make target 'prefs.js', needed by 'po/dash-to-panel.pot'.  Stop.