### PR TITLE
Initialize DesktopIconsUsable area in constructor

### DIFF
--- a/src/panelManager.js
+++ b/src/panelManager.js
@@ -60,6 +60,7 @@ export const PanelManager = class {
   constructor() {
     this.overview = new Overview.Overview(this)
     this._injectionManager = new InjectionManager()
+    this._desktopIconsUsableArea = new DesktopIconsIntegration.DesktopIconsUsableAreaClass()
   }
 
   enable(reset) {
@@ -370,6 +371,8 @@ export const PanelManager = class {
         -1,
       )
     }
+
+    this._desktopIconsUsableArea.resetMargins()
 
     if (reset) return
 


### PR DESCRIPTION
On startup, this._desktopIconsUsableArea is not set as it is not initialized before this._setDesktopIconsMargins is called.

Therefore on DING and gtk4-ding, icons slide under the panel.

If the panel is repositioned or reset in any way, it behaves correctly.

With this change, desktopIconsUsablearea is initialized in the constructor.

The margins are set to 0 in disable(reset = true);

The entire class is destroyed with disable();