### PR TITLE
Fixes to hiding panel in overview

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -615,6 +615,11 @@
       <summary>Hide overview on startup</summary>
       <description>Hide overview on startup, which would be shown by default at gnome startup.</description>
     </key>
+    <key type="b" name="hide-panel-in-overview">
+      <default>false</default>
+      <summary>Hide panel in overview</summary>
+      <description>Hide panel in overview, which avoids functionality duplication when also showing the original gnome dash.</description>
+    </key>
     <key type="b" name="group-apps">
       <default>true</default>
       <summary>Group applications</summary>

--- a/src/intellihide.js
+++ b/src/intellihide.js
@@ -460,8 +460,7 @@ export const Intellihide = class {
   _checkIfShouldBeVisible(fromRevealMechanism) {
     if (
         Main.overview.visibleTarget && 
-        SETTINGS.get_boolean('hide-panel-in-overview') &&
-        Main.overview.dash?.visible
+        SETTINGS.get_boolean('hide-panel-in-overview')
     ){
         return false
     }

--- a/src/intellihide.js
+++ b/src/intellihide.js
@@ -459,6 +459,13 @@ export const Intellihide = class {
 
   _checkIfShouldBeVisible(fromRevealMechanism) {
     if (
+        Main.overview.visibleTarget && 
+        SETTINGS.get_boolean('hide-panel-in-overview') &&
+        Main.overview.dash?.visible
+    ){
+        return false
+    }
+    if (
       Main.overview.visibleTarget ||
       this._dtpPanel.taskbar.previewMenu.opened ||
       this._dtpPanel.taskbar._dragMonitor ||

--- a/src/overview.js
+++ b/src/overview.js
@@ -114,8 +114,9 @@ export const Overview = class {
         if (focusedPanel) {
           let position = focusedPanel.geom.position
           let isBottom = position == St.Side.BOTTOM
+          const hideInOverview = SETTINGS.get_boolean('hide-panel-in-overview')
 
-          if (focusedPanel.intellihide?.enabled) {
+          if (focusedPanel.intellihide?.enabled && !hideInOverview) {
             // Panel intellihide is enabled (struts aren't taken into account on overview allocation),
             // dynamically modify the overview box to follow the reveal/hide animation
             let { transitioning, finalState, progress } =
@@ -129,7 +130,7 @@ export const Overview = class {
             if (isBottom || position == St.Side.RIGHT)
               box[focusedPanel.fixedCoord.c2] -= size
             else box[focusedPanel.fixedCoord.c1] += size
-          } else if (isBottom)
+          } else if (isBottom && !hideInOverview)
             // The default overview allocation takes into account external
             // struts, everywhere but the bottom where the dash is usually fixed anyway.
             // If there is a bottom panel under the dash location, give it some space here

--- a/src/panel.js
+++ b/src/panel.js
@@ -708,13 +708,15 @@ export const Panel = GObject.registerClass(
     }
 
     _adjustForOverview() {
-      let isFocusedMonitor = this.panelManager.checkIfFocusedMonitor(
+      const isFocusedMonitor = this.panelManager.checkIfFocusedMonitor(
         this.monitor,
       )
-      let isOverview = !!Main.overview.visibleTarget
-      let isOverviewFocusedMonitor = isOverview && isFocusedMonitor
-      let isShown = !isOverview || isOverviewFocusedMonitor
-      let actorData = Utils.getTrackedActorData(this.panelBox)
+      const isOverview = !!Main.overview.visibleTarget
+      const isOverviewFocusedMonitor = isOverview && isFocusedMonitor
+      const hideInOverview = SETTINGS.get_boolean('hide-panel-in-overview')
+      const isShown =
+        !isOverview || (isOverviewFocusedMonitor && !hideInOverview)
+      const actorData = Utils.getTrackedActorData(this.panelBox)
 
       // prevent the "chrome" to update the panelbox visibility while in overview
       actorData.trackFullscreen = !isOverview

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -2532,6 +2532,13 @@ const Preferences = class {
     )
 
     this._settings.bind(
+      'hide-panel-in-overview',
+      this._builder.get_object('hide_panel_in_overview_switch'),
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    )
+
+    this._settings.bind(
       'group-apps',
       this._builder.get_object('group_apps_switch'),
       'active',

--- a/ui/SettingsBehavior.ui
+++ b/ui/SettingsBehavior.ui
@@ -185,6 +185,17 @@
           </object>
         </child>
 
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Hide panel in overview</property>
+            <child>
+              <object class="GtkSwitch" id="hide_panel_in_overview_switch">
+                <property name="valign">center</property>
+              </object>
+            </child>
+          </object>
+        </child>
+
       </object>
     </child>
 


### PR DESCRIPTION
Fixed behavior of hiding panel in overview while intellihide is activated and removed blank space from overview when panel is hidden.

**Note**: It builds on the unapproved PR #2349 Please review that PR alongside this one, as my changes depend on it.