### PR TITLE
Vertical panel time ellipsis post-Gnome update (ASCII colon split)

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -1357,7 +1357,7 @@ export const Panel = GObject.registerClass(
           !setClockText(datetimeParts) &&
           !setClockText(time)
         ) {
-          let timeParts = time.split('∶')
+          let timeParts = time.split(':')
 
           if (!this._clockFormat) {
             this._clockFormat = DESKTOPSETTINGS.get_string('clock-format')


### PR DESCRIPTION
After a Gnome update, the Dash-to-Panel plugin showed ellipses for time in vertical mode. Analysis revealed the hour - minute separator changed to an ASCII colon.

To fix this, I updated the code's delimiter to the ASCII colon. Post - modification, time display is back to normal, ensuring users see accurate time in vertical mode post - update.
![Uploading Screenshot From 2025-07-19 08-23-42.png…]()
