### PR TITLE
Fix cache bug

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -155,6 +155,7 @@ export default class DashToPanelExtension extends Extension {
 
     PanelSettings.disable(SETTINGS)
     panelManager.disable()
+    PanelSettings.clearCache()
 
     DTP_EXTENSION = null
     SETTINGS = null

--- a/src/panelSettings.js
+++ b/src/panelSettings.js
@@ -46,6 +46,7 @@ export var availableMonitors = []
 
 export async function init(settings) {
   useCache = true
+  cache = {}
   prefsOpenedId = settings.connect(
     'changed::prefs-opened',
     () => (useCache = !settings.get_boolean('prefs-opened')),


### PR DESCRIPTION
This patch ensures that the panel settings cache is cleared when disabling the extension as well as when initializing panel settings.
This fixes an issue where settings were sometimes overwritten by stale values in the adjustMonitorSettings function, as well as freeing up memory while the extension is disabled.

The old cache would persist after disabling the extension and would remain if the extension was re-enabled, so if some of Dash to Panel's gsettings were changed while the extension was disabled, they would be overwritten by stale cache values when re-enabling the extension as the cache only gets updated while the extension is running.