### PR TITLE
Maintain notification counter badge even when focused the windows mistakenly or changed workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dash-to-panel@jderose9.github.com*.zip
 po/dash-to-panel.pot
 ui/*.ui.h
 node_modules/
+dash-to-panel.code-workspace

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "shell-version": [ "46", "47", "48", "49" ],
   "url": "https://github.com/home-sweet-gnome/dash-to-panel",
   "gettext-domain": "dash-to-panel",
-  "version": 9999,
+  "version": 73,
   "donations": {
       "paypal": "charlesg99"
   }

--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -462,6 +462,10 @@ export const TaskbarAppIcon = GObject.registerClass(
       this._updateWindows()
       this.updateIcon()
 
+      // Update notification badge when windows changed to avoid showing badge when closed all app's windows
+      this._maybeUpdateNumberOverlay()
+      // this._handleNotifications();
+
       if (this._isGroupApps) this._setIconStyle()
     }
 
@@ -1658,13 +1662,48 @@ export const TaskbarAppIcon = GObject.registerClass(
         `${showNotifications ? 'add' : 'remove'}_style_class_name`
       ]('notification-badge')
 
+
+      // We check if the app is running, and that the # of windows is > 0 in
+      // case we use workspace isolation,
+      let appCount = this.getAppIconInterestingWindows().length
+      let appIsRunning =
+        this.app.state == Shell.AppState.RUNNING 
+          && appCount > 0
+        // this.app.state == 1 // looks like stopped
+        // this.app.state == 0
+        // this.app.state == 2
+        // appCount > 0
+
+      console.warn("appIsRunning = " + appIsRunning)
+
       if (shouldBeVisible && label !== this._numberOverlayLabel.get_text()) {
         this._numberOverlayLabel.set_text(label.toString())
         this._updateNumberOverlay()
       }
+      
 
-      if (visible && !shouldBeVisible) this._numberOverlayBin.hide()
+      // if (appIsRunning)
+      if (visible && !shouldBeVisible) {
+        this._numberOverlayBin.hide()
+        console.warn("entered if (visible && !shouldBeVisible)")
+      }
       else if (!visible && shouldBeVisible) this._numberOverlayBin.show()
+      // else if (visible && shouldBeVisible) this._numberOverlayBin.show()
+      // else
+      //    this._numberOverlayBin.hide()
+
+      if (!appIsRunning) {
+
+        this._notificationsCount = 0
+        this._numberOverlayLabel.set_text("0")
+        this._updateNumberOverlay()
+        this._numberOverlayBin.hide()
+      }
+
+      console.warn("visible = " + visible)
+      console.warn("shouldBeVisible = " + shouldBeVisible)
+      console.warn("this._notificationsCount = " + this._notificationsCount)
+      console.warn("_numberOverlayLabel = " + this._numberOverlayLabel.get_text())
     }
 
     _numberOverlay() {

--- a/src/notificationsMonitor.js
+++ b/src/notificationsMonitor.js
@@ -60,8 +60,9 @@ export const NotificationsMonitor = class extends EventEmitter {
         let appId = tracker.focus_app?.id
 
         // reset notifications from message tray on app focus
-        if (tracker.focus_app && this._state[appId])
-          this._updateState(tracker.focus_app.id, this._getDefaultState(), true)
+        // disabled to maintain notifications even when focused the windows mistakenly
+        // if (tracker.focus_app && this._state[appId])
+        //   this._updateState(tracker.focus_app.id, this._getDefaultState(), true)
       },
     ])
     this._acquireUnityDBus()
@@ -115,10 +116,17 @@ export const NotificationsMonitor = class extends EventEmitter {
 
     this._state[appId] = Object.assign(this._state[appId], state)
 
-    if (tracker.focus_app?.id == appId) {
-      this._state[appId].count = 0
-      this._state[appId].trayCount = 0
-    }
+    // Disabled to not reset notifications when focused app mistakenly
+    // if (tracker.focus_app?.id == appId) {
+    //   this._state[appId].count = 0
+    //   this._state[appId].trayCount = 0
+    // }
+
+    // Checking if the app is closed
+    // We check if the app is running, and that the # of windows is > 0 in
+    // case we use workspace isolation,
+    // let appIsRunning =
+    //   this.app.state == Shell.AppState.RUNNING && appCount > 0
 
     this._state[appId].urgent =
       state.urgent ||


### PR DESCRIPTION
Hi!

This is a proposal of the notification badge behavior: _Maintain notification counter badge even when focused the windows mistakenly or changed workspace._

The original behavior is cleaning the badge when focus the app window or change workspace. This occurs even when the app has a notification active. This behavior causes a little confusion.

The proposal grants more readability of app notifications especially favorite ones.