### PR TITLE
Gnome 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "uuid": "dash-to-panel@jderose9.github.com",
   "name": "Dash to Panel",
   "description": "An icon taskbar for the Gnome Shell. This extension moves the dash into the gnome main panel so that the application launchers and system tray are combined into a single panel, similar to that found in KDE Plasma and Windows 7+. A separate dock is no longer needed for easy access to running and favorited applications.\n\nFor a more traditional experience, you may also want to use Tweak Tool to enable Windows > Titlebar Buttons > Minimize & Maximize.\n\nFor the best support, please report any issues on Github. Dash-to-panel is developed and maintained by @jderose9 and @charlesg99.",
-  "shell-version": [ "46", "47", "48", "49" ],
+  "shell-version": [ "46", "47", "48", "49", "50" ],
   "url": "https://github.com/home-sweet-gnome/dash-to-panel",
   "gettext-domain": "dash-to-panel",
   "version": 9999,

--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -911,7 +911,6 @@ export const TaskbarAppIcon = GObject.registerClass(
 
       this.set_hover(true)
       this._menu.open(BoxPointer.PopupAnimation.FULL)
-      this._menuManager.ignoreRelease()
       this.emit('sync-tooltip')
 
       return false
@@ -2223,7 +2222,6 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
 
     this.actor.set_hover(true)
     this._menu.open(BoxPointer.PopupAnimation.FULL)
-    this._menuManager.ignoreRelease()
     this.emit('sync-tooltip')
 
     return false

--- a/src/intellihide.js
+++ b/src/intellihide.js
@@ -262,15 +262,12 @@ export const Intellihide = class {
         ['showing', 'hiding'],
         () => this._queueUpdatePanelPosition(),
       ],
-    )
-
-    if (Meta.is_wayland_compositor()) {
-      this._signalsHandler.add([
+      [
         this._panelBox,
         'notify::visible',
         () => Utils.setDisplayUnredirect(!this._panelBox.visible),
-      ])
-    }
+      ]
+    )
   }
 
   _setTrackPanel(enable) {

--- a/src/panel.js
+++ b/src/panel.js
@@ -207,7 +207,9 @@ export const Panel = GObject.registerClass(
 
       this.add_child(this.panel)
 
-      if (Main.panel._onButtonPress || Main.panel._tryDragWindow) {
+      if (Main.panel._onButtonPress || Main.panel._tryDragWindow || Main.panel._clickGesture) {
+        if (Main.panel._clickGesture) Main.panel._clickGesture.set_enabled(false)
+
         this._signalsHandler.add([
           this.panel,
           ['button-press-event', 'touch-event'],

--- a/src/panelManager.js
+++ b/src/panelManager.js
@@ -670,7 +670,7 @@ export const PanelManager = class {
       Main.layoutManager.removeChrome(panelBox)
     }
 
-    Main.layoutManager.addChrome(clipContainer, { affectsInputRegion: false })
+    Main.layoutManager.addChrome(clipContainer)
     clipContainer.add_child(panelBox)
 
     panel = new Panel.Panel(
@@ -687,10 +687,7 @@ export const PanelManager = class {
     panelBox.set_position(0, 0)
     panelBox.set_width(-1)
 
-    Main.layoutManager.trackChrome(panel, {
-      affectsInputRegion: true,
-      affectsStruts: false,
-    })
+    Main.layoutManager.trackChrome(panel, { affectsStruts: false })
 
     Main.layoutManager.trackChrome(panelBox, {
       trackFullscreen: true,

--- a/src/windowPreview.js
+++ b/src/windowPreview.js
@@ -110,8 +110,8 @@ export const PreviewMenu = GObject.registerClass(
       this._timeoutsHandler = new Utils.TimeoutsHandler()
       this._signalsHandler = new Utils.GlobalSignalsHandler()
 
-      Main.layoutManager.addChrome(this, { affectsInputRegion: false })
-      Main.layoutManager.trackChrome(this.menu, { affectsInputRegion: true })
+      Main.layoutManager.addChrome(this)
+      Main.layoutManager.trackChrome(this.menu)
 
       this._resetHiddenState()
       this._refreshGlobals()


### PR DESCRIPTION
I just tweaked a couple of lines of code to make the extension work on Gnome 50 ([adapt to dropped X11 backend from Mutter](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3768)). I didn't consider how this would affect the extension in Gnome < 50. Furthermore, I didn't test all combinations of settings, so something might still be broken. This PR is for people who want to try the latest Gnome and want to patch "Dash to Panel" locally.

I think a proper update of the extension will need to be much more involved due to the X11 backend drop in Gnome 50.