### PR TITLE
Support light mode panel for apps icon

### DIFF
--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -2144,6 +2144,22 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
     )
 
     this.setShowAppsPadding()
+    this._updateIconColor()
+
+    this._panelStyleChangedId = dtpPanel.panel.connect('style-changed', () =>
+      this._updateIconColor(),
+    )
+  }
+
+  _updateIconColor() {
+    if (!this.realShowAppsIcon._dtpPanel.dynamicTransparency) return
+
+    let isBright = this.realShowAppsIcon._dtpPanel._getBackgroundBrightness()
+    if (isBright) {
+      this.actor.add_style_class_name('bright-panel')
+    } else {
+      this.actor.remove_style_class_name('bright-panel')
+    }
   }
 
   _onButtonPress(_actor, event) {
@@ -2241,6 +2257,12 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
     SETTINGS.disconnect(this._changedShowAppsIconId)
     SETTINGS.disconnect(this._changedAppIconSidePaddingId)
     SETTINGS.disconnect(this._changedAppIconPaddingId)
+
+    if (this._panelStyleChangedId) {
+      this.realShowAppsIcon._dtpPanel.panel.disconnect(
+        this._panelStyleChangedId,
+      )
+    }
 
     this.realShowAppsIcon.destroy()
   }

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -55,6 +55,9 @@
 .dashtopanelMainPanel .dash-item-container .show-apps .overview-icon {
 	color: #FFF;
 }
+.dashtopanelMainPanel .dash-item-container .show-apps.bright-panel .overview-icon {
+	color: #000;
+}
 .dashtopanelMainPanel .dash-item-container .show-apps:hover .overview-icon {
 	background: none;
 }


### PR DESCRIPTION
Just a small PR that allows the "Show Applications" button to adapt to light panels when the Light Style official extension is enabled https://gitlab.gnome.org/GNOME/gnome-shell-extensions

While by default, the panel has a dark background color even in Light mode, if the official extension is enabled, the panel has a light background and the button disappears.

https://github.com/user-attachments/assets/0eedc6de-3cff-46a7-82a8-0370cb5a808e