### PR TITLE
Fix desktop hover indicator when using panel border-radius > 0px. Fixes #2452

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -1429,7 +1429,9 @@ export const Panel = GObject.registerClass(
         if (this._showDesktopButton) return
 
         this._showDesktopButton = new St.Bin({
-          style_class: 'showdesktop-button',
+	  style_class: this.geom.vertical
+		? 'showdesktop-button-vertical'
+		: 'showdesktop-button',
           reactive: true,
           can_focus: true,
           // x_fill: true,

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -186,6 +186,10 @@
 	border-radius: 0 4px 4px 0 !important;
 }
 
+#uiGroup.br4 .dashtopanelPanel.dock .showdesktop-button-vertical {
+	border-radius: 0 0 4px 4px !important;
+}
+
 #uiGroup.br8 .dashtopanelPanel.dock,
 #uiGroup.br8 .dashtopanelPanel.dock .dashtopanelMainPanel,
 #uiGroup.br8 .show-apps,
@@ -200,6 +204,10 @@
 }
 #uiGroup.br8 .dashtopanelPanel.dock .showdesktop-button { 
 	border-radius: 0 8px 8px 0 !important;
+}
+
+#uiGroup.br8 .dashtopanelPanel.dock .showdesktop-button-vertical {
+	border-radius: 0 0 8px 8px !important;
 }
 
 #uiGroup.br12 .dashtopanelPanel.dock,
@@ -218,6 +226,10 @@
 	border-radius: 0 12px 12px 0 !important;
 }
 
+#uiGroup.br12 .dashtopanelPanel.dock .showdesktop-button-vertical {
+	border-radius: 0 0 12px 12px !important;
+}
+
 #uiGroup.br16 .dashtopanelPanel.dock,
 #uiGroup.br16 .dashtopanelPanel.dock .dashtopanelMainPanel,
 #uiGroup.br16 .show-apps,
@@ -234,6 +246,10 @@
 	border-radius: 0 16px 16px 0 !important;
 }
 
+#uiGroup.br16 .dashtopanelPanel.dock .showdesktop-button-vertical {
+	border-radius: 0 0 16px 16px !important;
+}
+
 #uiGroup.br20 .dashtopanelPanel.dock,
 #uiGroup.br20 .dashtopanelPanel.dock .dashtopanelMainPanel,
 #uiGroup.br20 .show-apps,
@@ -248,4 +264,8 @@
 }
 #uiGroup.br20 .dashtopanelPanel.dock .showdesktop-button { 
 	border-radius: 0 20px 20px 0 !important;
+}
+
+#uiGroup.br20 .dashtopanelPanel.dock .showdesktop-button-vertical {
+	border-radius: 0 0 20px 20px !important;
 }


### PR DESCRIPTION
Panel border radius:16px, 'show desktop' button height: 17px: 

Before
<img width="79" height="49" alt="2026-01-25_18-56" src="https://github.com/user-attachments/assets/5b550489-0012-48ba-85a9-15ac62cbe758" />

After
<img width="352" height="180" alt="2026-01-25_18-51" src="https://github.com/user-attachments/assets/da7b59e3-c361-4940-b213-e4687560b961" />

---

Both at 8px:

Before:
<img width="205" height="304" alt="2026-01-25_18-55" src="https://github.com/user-attachments/assets/9e0b4c3c-1a80-499f-a789-204af31c08b0" />

After: 
<img width="114" height="106" alt="2026-01-25_18-54" src="https://github.com/user-attachments/assets/38745203-87e5-4a76-8ddb-c4824953ecc9" />


Please refer to #2452 for more details.

NOTE: The gap at the bottom of the button left by the indicator can be resolved by changing the size of the 'show desktop' button(in the first example 17px(try 15px also) for 16px panel border radius)