### PR TITLE
Fix signal disposal memory leak on GNOME Shell 49

### DIFF
--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -452,10 +452,34 @@ export const TaskbarAppIcon = GObject.registerClass(
         this._updateIconIdleId = 0
       }
 
+      if (this._iconIconBinActorAddedId) {
+        this.icon._iconBin.disconnect(this._iconIconBinActorAddedId)
+        this._iconIconBinActorAddedId = 0
+      }
+
+      if (this._mappedId) {
+        this.disconnect(this._mappedId)
+        this._mappedId = 0
+      }
+
+      if (this._focusedDotsRepaintId) {
+        this._focusedDots.disconnect(this._focusedDotsRepaintId)
+        this._focusedDotsRepaintId = 0
+      }
+
+      if (this._unfocusedDotsRepaintId) {
+        this._unfocusedDots.disconnect(this._unfocusedDotsRepaintId)
+        this._unfocusedDotsRepaintId = 0
+      }
+
       this._timeoutsHandler.destroy()
       this._signalsHandler.destroy()
 
       this._previewMenu.close(true)
+
+      this._previewMenu = null
+      this.iconAnimator = null
+      this.dtpPanel = null
     }
 
     onWindowsChanged() {
@@ -636,15 +660,16 @@ export const TaskbarAppIcon = GObject.registerClass(
           visible: false,
         })
 
-        let mappedId = this.connect('notify::mapped', () => {
+        this._mappedId = this.connect('notify::mapped', () => {
           this._displayProperIndicator()
-          this.disconnect(mappedId)
+          this.disconnect(this._mappedId)
+          this._mappedId = 0
         })
       } else {
         ;(this._focusedDots = new St.DrawingArea()),
           (this._unfocusedDots = new St.DrawingArea())
 
-        this._focusedDots.connect('repaint', () => {
+        this._focusedDotsRepaintId = this._focusedDots.connect('repaint', () => {
           if (!this._dashItemContainer.animatingOut)
             // don't draw and trigger more animations if the icon is in the middle of
             // being removed from the panel
@@ -655,7 +680,7 @@ export const TaskbarAppIcon = GObject.registerClass(
             )
         })
 
-        this._unfocusedDots.connect('repaint', () => {
+        this._unfocusedDotsRepaintId = this._unfocusedDots.connect('repaint', () => {
           if (!this._dashItemContainer.animatingOut)
             this._drawRunningIndicator(
               this._unfocusedDots,
@@ -2091,11 +2116,11 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
     // No action on clicked (showing of the appsview is controlled elsewhere)
     this._onClicked = () => this._removeMenuTimeout()
 
-    this.actor.connect('leave-event', this._onLeaveEvent.bind(this))
-    this.actor.connect('button-press-event', this._onButtonPress.bind(this))
-    this.actor.connect('touch-event', this._onTouchEvent.bind(this))
-    this.actor.connect('clicked', this._onClicked.bind(this))
-    this.actor.connect('popup-menu', this._onKeyboardPopupMenu.bind(this))
+    this._actorLeaveEventId = this.actor.connect('leave-event', this._onLeaveEvent.bind(this))
+    this._actorButtonPressEventId = this.actor.connect('button-press-event', this._onButtonPress.bind(this))
+    this._actorTouchEventId = this.actor.connect('touch-event', this._onTouchEvent.bind(this))
+    this._actorClickedId = this.actor.connect('clicked', this._onClicked.bind(this))
+    this._actorPopupMenuId = this.actor.connect('popup-menu', this._onKeyboardPopupMenu.bind(this))
 
     this._menu = null
     this._menuManager = new PopupMenu.PopupMenuManager(this.actor)
@@ -2239,6 +2264,12 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
     SETTINGS.disconnect(this._changedShowAppsIconId)
     SETTINGS.disconnect(this._changedAppIconSidePaddingId)
     SETTINGS.disconnect(this._changedAppIconPaddingId)
+
+    this.actor.disconnect(this._actorLeaveEventId)
+    this.actor.disconnect(this._actorButtonPressEventId)
+    this.actor.disconnect(this._actorTouchEventId)
+    this.actor.disconnect(this._actorClickedId)
+    this.actor.disconnect(this._actorPopupMenuId)
 
     this.realShowAppsIcon.destroy()
   }

--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -544,13 +544,17 @@ export const TaskbarAppIcon = GObject.registerClass(
             if (this.icon._iconBin.child.mapped) {
               this.icon._iconBin.child.set_size(size, size)
             } else {
-              let iconMappedId = this.icon._iconBin.child.connect(
-                'notify::mapped',
-                () => {
-                  this.icon._iconBin.child.set_size(size, size)
-                  this.icon._iconBin.child.disconnect(iconMappedId)
-                },
-              )
+              // Capture the specific child reference: _iconBin.child can be
+              // swapped before notify::mapped fires, which would make the
+              // live-lookup disconnect target the wrong object and produce
+              // "instance has no handler with id" GObject errors.
+              const child = this.icon._iconBin.child
+              let iconMappedId = child.connect('notify::mapped', () => {
+                if (!iconMappedId) return
+                child.set_size(size, size)
+                child.disconnect(iconMappedId)
+                iconMappedId = 0
+              })
             }
           },
         )
@@ -2218,14 +2222,24 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
         this.realShowAppsIcon,
         this.realShowAppsIcon._dtpPanel,
       )
-      this._menu.connect('open-state-changed', (menu, isPoppedUp) => {
-        if (!isPoppedUp) this._onMenuPoppedDown()
-      })
-      let id = Main.overview.connect('hiding', () => {
+      // Track handler ids on properties so destroy() can clean them up.
+      // The menu outlives MyShowAppsIcon when the extension is disabled
+      // (menu.actor is parented to Main.uiGroup), so without explicit
+      // disconnect the Main.overview handler pins the whole icon tree.
+      this._menuOpenStateId = this._menu.connect(
+        'open-state-changed',
+        (menu, isPoppedUp) => {
+          if (!isPoppedUp) this._onMenuPoppedDown()
+        },
+      )
+      this._overviewHidingId = Main.overview.connect('hiding', () => {
         this._menu.close()
       })
       this._menu.actor.connect('destroy', () => {
-        Main.overview.disconnect(id)
+        if (this._overviewHidingId) {
+          Main.overview.disconnect(this._overviewHidingId)
+          this._overviewHidingId = 0
+        }
       })
 
       // We want to keep the item hovered while the menu is up
@@ -2270,6 +2284,19 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
     this.actor.disconnect(this._actorTouchEventId)
     this.actor.disconnect(this._actorClickedId)
     this.actor.disconnect(this._actorPopupMenuId)
+
+    if (this._menu) {
+      if (this._menuOpenStateId) {
+        this._menu.disconnect(this._menuOpenStateId)
+        this._menuOpenStateId = 0
+      }
+      if (this._overviewHidingId) {
+        Main.overview.disconnect(this._overviewHidingId)
+        this._overviewHidingId = 0
+      }
+      this._menu.destroy()
+      this._menu = null
+    }
 
     this.realShowAppsIcon.destroy()
   }

--- a/src/panel.js
+++ b/src/panel.js
@@ -441,7 +441,13 @@ export const Panel = GObject.registerClass(
 
       this.menuManager._changeMenu = this.menuManager._oldChangeMenu
 
-      this._unmappedButtons.forEach((a) => this._disconnectVisibleId(a))
+      this._unmappedButtons.forEach((a) => {
+        try {
+          this._disconnectVisibleId(a)
+        } catch (e) {
+          // actor may have already been destroyed
+        }
+      })
 
       if (this.statusArea.dateMenu) {
         this.statusArea.dateMenu._clockDisplay.text =
@@ -1453,53 +1459,70 @@ export const Panel = GObject.registerClass(
 
         this._setShowDesktopButtonStyle()
 
-        this._showDesktopButton.connect('touch-event', (actor, event) => {
-          if (event.type() == Clutter.EventType.TOUCH_BEGIN) {
-            this._onShowDesktopButtonPress()
-          }
-        })
-        this._showDesktopButton.connect('button-press-event', () =>
-          this._onShowDesktopButtonPress(),
-        )
-        this._showDesktopButton.connect('enter-event', () => {
-          this._showDesktopButton.add_style_class_name(
-            this._getBackgroundBrightness()
-              ? 'showdesktop-button-light-hovered'
-              : 'showdesktop-button-dark-hovered',
-          )
+        this._showDesktopButtonSignalIds = []
 
-          if (SETTINGS.get_boolean('show-showdesktop-hover')) {
-            this._timeoutsHandler.add([
-              T4,
-              SETTINGS.get_int('show-showdesktop-delay'),
-              () => {
-                this._hiddenDesktopWorkspace =
-                  Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace()
-                this._toggleWorkspaceWindows(true, this._hiddenDesktopWorkspace)
-              },
-            ])
-          }
-        })
-
-        this._showDesktopButton.connect('leave-event', () => {
-          this._showDesktopButton.remove_style_class_name(
-            this._getBackgroundBrightness()
-              ? 'showdesktop-button-light-hovered'
-              : 'showdesktop-button-dark-hovered',
-          )
-
-          if (SETTINGS.get_boolean('show-showdesktop-hover')) {
-            if (this._timeoutsHandler.getId(T4)) {
-              this._timeoutsHandler.remove(T4)
-            } else if (this._hiddenDesktopWorkspace) {
-              this._toggleWorkspaceWindows(false, this._hiddenDesktopWorkspace)
+        this._showDesktopButtonSignalIds.push(
+          this._showDesktopButton.connect('touch-event', (actor, event) => {
+            if (event.type() == Clutter.EventType.TOUCH_BEGIN) {
+              this._onShowDesktopButtonPress()
             }
-          }
-        })
+          }),
+        )
+        this._showDesktopButtonSignalIds.push(
+          this._showDesktopButton.connect('button-press-event', () =>
+            this._onShowDesktopButtonPress(),
+          ),
+        )
+        this._showDesktopButtonSignalIds.push(
+          this._showDesktopButton.connect('enter-event', () => {
+            this._showDesktopButton.add_style_class_name(
+              this._getBackgroundBrightness()
+                ? 'showdesktop-button-light-hovered'
+                : 'showdesktop-button-dark-hovered',
+            )
+
+            if (SETTINGS.get_boolean('show-showdesktop-hover')) {
+              this._timeoutsHandler.add([
+                T4,
+                SETTINGS.get_int('show-showdesktop-delay'),
+                () => {
+                  this._hiddenDesktopWorkspace =
+                    Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace()
+                  this._toggleWorkspaceWindows(true, this._hiddenDesktopWorkspace)
+                },
+              ])
+            }
+          }),
+        )
+
+        this._showDesktopButtonSignalIds.push(
+          this._showDesktopButton.connect('leave-event', () => {
+            this._showDesktopButton.remove_style_class_name(
+              this._getBackgroundBrightness()
+                ? 'showdesktop-button-light-hovered'
+                : 'showdesktop-button-dark-hovered',
+            )
+
+            if (SETTINGS.get_boolean('show-showdesktop-hover')) {
+              if (this._timeoutsHandler.getId(T4)) {
+                this._timeoutsHandler.remove(T4)
+              } else if (this._hiddenDesktopWorkspace) {
+                this._toggleWorkspaceWindows(false, this._hiddenDesktopWorkspace)
+              }
+            }
+          }),
+        )
 
         this.panel.add_child(this._showDesktopButton)
       } else {
         if (!this._showDesktopButton) return
+
+        if (this._showDesktopButtonSignalIds) {
+          this._showDesktopButtonSignalIds.forEach((id) =>
+            this._showDesktopButton.disconnect(id),
+          )
+          this._showDesktopButtonSignalIds = null
+        }
 
         this.panel.remove_child(this._showDesktopButton)
         this._showDesktopButton.destroy()

--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -263,18 +263,21 @@ export const Taskbar = class extends EventEmitter {
       enable_mouse_scrolling: true,
     })
 
-    this._scrollView.connect('leave-event', this._onLeaveEvent.bind(this))
-    this._scrollView.connect('motion-event', this._onMotionEvent.bind(this))
-    this._scrollView.connect('scroll-event', this._onScrollEvent.bind(this))
+    this._signalsHandler.add(
+      [this._scrollView, 'leave-event', this._onLeaveEvent.bind(this)],
+      [this._scrollView, 'motion-event', this._onMotionEvent.bind(this)],
+      [this._scrollView, 'scroll-event', this._onScrollEvent.bind(this)],
+    )
     this._scrollView.add_child(this._box)
 
     this._showAppsIconWrapper = panel.showAppsIconWrapper
-    this._showAppsIconWrapper.connect(
+    this._signalsHandler.add([
+      this._showAppsIconWrapper,
       'menu-state-changed',
       (showAppsIconWrapper, opened) => {
         this._itemMenuStateChanged(showAppsIconWrapper, opened)
       },
-    )
+    ])
     // an instance of the showAppsIcon class is encapsulated in the wrapper
     this._showAppsIcon = this._showAppsIconWrapper.realShowAppsIcon
     this.showAppsButton = this._showAppsIcon.toggleButton
@@ -283,10 +286,11 @@ export const Taskbar = class extends EventEmitter {
       this.showAppsButton.set_width(panel.geom.w)
     }
 
-    this.showAppsButton.connect(
+    this._signalsHandler.add([
+      this.showAppsButton,
       'notify::checked',
       this._onShowAppsButtonToggled.bind(this),
-    )
+    ])
 
     this.showAppsButton.checked = SearchController._showAppsButton
       ? SearchController._showAppsButton.checked
@@ -743,12 +747,18 @@ export const Taskbar = class extends EventEmitter {
   }
 
   _hookUpLabel(item, syncHandler) {
-    item.child.connect('notify::hover', () => {
+    let hoverId = item.child.connect('notify::hover', () => {
       this._syncLabel(item, syncHandler)
     })
 
-    syncHandler.connect('sync-tooltip', () => {
+    let syncId = syncHandler.connect('sync-tooltip', () => {
       this._syncLabel(item, syncHandler)
+    })
+
+    let child = item.child
+    child.connect('destroy', () => {
+      child.disconnect(hoverId)
+      syncHandler.disconnect(syncId)
     })
   }
 
@@ -769,23 +779,6 @@ export const Taskbar = class extends EventEmitter {
       this.iconAnimator,
     )
 
-    if (appIcon._draggable) {
-      appIcon._draggable.connect('drag-begin', () => {
-        appIcon.opacity = 0
-        appIcon.isDragged = 1
-        this._dropIconAnimations()
-      })
-      appIcon._draggable.connect('drag-end', () => {
-        appIcon.opacity = 255
-        delete appIcon.isDragged
-        this._updateAppIcons()
-      })
-    }
-
-    appIcon.connect('menu-state-changed', (appIcon, opened) => {
-      this._itemMenuStateChanged(item, opened)
-    })
-
     let item = new TaskbarItemContainer()
 
     item._dtpPanel = this.dtpPanel
@@ -794,7 +787,27 @@ export const Taskbar = class extends EventEmitter {
     item.setChild(appIcon)
     appIcon._dashItemContainer = item
 
-    appIcon.connect('notify::hover', () => {
+    let appIconSignalIds = []
+    let draggableSignalIds = []
+
+    appIconSignalIds.push(appIcon.connect('menu-state-changed', (appIcon, opened) => {
+      this._itemMenuStateChanged(item, opened)
+    }))
+
+    if (appIcon._draggable) {
+      draggableSignalIds.push(appIcon._draggable.connect('drag-begin', () => {
+        appIcon.opacity = 0
+        appIcon.isDragged = 1
+        this._dropIconAnimations()
+      }))
+      draggableSignalIds.push(appIcon._draggable.connect('drag-end', () => {
+        appIcon.opacity = 255
+        delete appIcon.isDragged
+        this._updateAppIcons()
+      }))
+    }
+
+    appIconSignalIds.push(appIcon.connect('notify::hover', () => {
       if (appIcon.hover) {
         this._timeoutsHandler.add([
           T1,
@@ -821,17 +834,17 @@ export const Taskbar = class extends EventEmitter {
         if (!appIcon.isDragged && iconAnimationSettings.type == 'SIMPLE')
           appIcon.get_parent().raise(0)
       }
-    })
+    }))
 
-    appIcon.connect('clicked', (actor) => {
+    appIconSignalIds.push(appIcon.connect('clicked', (actor) => {
       Utils.ensureActorVisibleInScrollView(
         this._scrollView,
         actor,
         this._scrollView._dtpFadeSize,
       )
-    })
+    }))
 
-    appIcon.connect('key-focus-in', (actor) => {
+    appIconSignalIds.push(appIcon.connect('key-focus-in', (actor) => {
       let [x_shift, y_shift] = Utils.ensureActorVisibleInScrollView(
         this._scrollView,
         actor,
@@ -843,6 +856,13 @@ export const Taskbar = class extends EventEmitter {
       if (appIcon._menu) {
         appIcon._menu._boxPointer.xOffset = -x_shift
         appIcon._menu._boxPointer.yOffset = -y_shift
+      }
+    }))
+
+    appIcon.connect('destroy', () => {
+      appIconSignalIds.forEach(id => appIcon.disconnect(id))
+      if (appIcon._draggable) {
+        draggableSignalIds.forEach(id => appIcon._draggable.disconnect(id))
       }
     })
 
@@ -1628,7 +1648,7 @@ export const TaskbarItemContainer = GObject.registerClass(
       let boundProperty = this._dtpPanel.geom.vertical
         ? 'translation_y'
         : 'translation_x'
-      this.bind_property(
+      let propertyBinding = this.bind_property(
         boundProperty,
         cloneContainer,
         boundProperty,
@@ -1654,6 +1674,7 @@ export const TaskbarItemContainer = GObject.registerClass(
       // The clone itself
       this._raisedClone = cloneButton.child
       this._raisedClone.connect('destroy', () => {
+        propertyBinding.unbind()
         adjustment.disconnect(adjustmentChangedId)
         taskbarBox.disconnect(taskbarBoxAllocationChangedId)
         GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {

--- a/src/windowPreview.js
+++ b/src/windowPreview.js
@@ -1068,7 +1068,15 @@ export const Preview = GObject.registerClass(
         this._waitWindowId = 0
       }
 
-      this._removeWindowSignals()
+      if (this._menuStateChangedId && this._contextMenu) {
+        this._contextMenu.disconnect(this._menuStateChangedId)
+        this._menuStateChangedId = 0
+        this._contextMenu = null
+      }
+
+      if (this.window) {
+        this._removeWindowSignals()
+      }
     }
 
     _onHoverChanged() {
@@ -1142,7 +1150,8 @@ export const Preview = GObject.registerClass(
 
       let menu = Main.wm._windowMenuManager._manager._menus[0]
 
-      menu.connect('open-state-changed', (menu, opened) => {
+      this._contextMenu = menu
+      this._menuStateChangedId = menu.connect('open-state-changed', (menu, opened) => {
         if (!opened) {
           delete this._previewMenu.hasGrab
 


### PR DESCRIPTION
## Summary

- Fixes signal handlers connected to Clutter actors via raw `.connect()` that were never disconnected on destroy, causing thousands of "Object has been already disposed" GC errors and a severe memory leak
- On a 4-monitor setup, gnome-shell RSS would grow from ~0.9 GB to 7+ GB within hours, eventually crashing the session
- Root cause in `taskbar.js`: cleanup handlers listened on the **parent** container's `destroy` signal, but Clutter destroys children first — so the child (`appIcon`) was already disposed when `disconnect()` was called

## Changes

**taskbar.js** (highest impact — ~6 leaked signals per app icon, created/destroyed continuously):
- Move `scrollView` and `showAppsButton` signals into `GlobalSignalsHandler`
- Store per-icon signal IDs and disconnect via `appIcon.connect('destroy')` instead of `item.connect('destroy')`
- Clean up `_hookUpLabel` signals on child destroy
- Unbind `bind_property` binding in `_createRaisedClone` destroy handler

**appIcons.js:**
- Disconnect `_iconIconBinActorAddedId`, `_mappedId`, and dot `repaint` handlers in `_onDestroy()`
- Null references to panel-level objects (`_previewMenu`, `iconAnimator`, `dtpPanel`)
- Track and disconnect `ShowAppsIconWrapper` actor signals in `destroy()`

**panel.js:**
- Track `_showDesktopButton` signal IDs and disconnect before `destroy()`
- Guard `_disconnectVisibleId` in `disable()` against already-destroyed actors

**windowPreview.js:**
- Guard `_removeWindowSignals()` against already-destroyed `MetaWindow`
- Track context menu `open-state-changed` signal and disconnect in `_onDestroy()`

## Test plan

- [x] Tested on GNOME Shell 49, Ubuntu 25.10, 4 monitors
- [x] "Already disposed" errors from dash-to-panel dropped from ~1000/hour to **zero**
- [x] gnome-shell RSS remains stable at ~0.9 GB (previously grew to 7+ GB)
- [ ] Test on single-monitor setup
- [ ] Test extension enable/disable cycle
- [ ] Long-running soak test (24+ hours)

Fixes #2439