### PR TITLE
Fix crash when Ubuntu Dock is already disabled on enable

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -146,7 +146,7 @@ export default class DashToPanelExtension extends Extension {
           200,
           completeEnable,
         )
-      }
+      } else completeEnable()
     } else completeEnable()
   }
 


### PR DESCRIPTION
## Problem

On Ubuntu, when Dash to Panel is enabled for the first time it disables Ubuntu Dock and stores it in the `disabled-extensions` list. On subsequent logins, if the user toggles Dash to Panel off via Extension Manager, GNOME Shell crashes with:

```
TypeError: panelManager is undefined
  disable@extension.js:157:5
```

## Root Cause

In `enable()`, the Ubuntu Dock handling has three paths:

1. Ubuntu Dock **not installed** → `completeEnable()` is called ✅
2. Ubuntu Dock **installed, not yet disabled** → disable it, wait 200ms, call `completeEnable()` ✅
3. Ubuntu Dock **installed and already disabled** → *(nothing)* ❌

In case 3, `completeEnable()` is never called, so `panelManager` is never initialized. When `disable()` later calls `panelManager.disable()` it crashes.

## Fix

Add `else completeEnable()` to handle the already-disabled case, matching the behaviour of the other two paths.

## Reproduction Steps

1. Install Ubuntu (Ubuntu Dock is present by default)
2. Enable Dash to Panel (it disables Ubuntu Dock automatically)
3. Log out and back in
4. Toggle Dash to Panel off in Extension Manager → **crash**