### PR TITLE
Implement configurable drag behaviour

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -635,6 +635,16 @@
       <summary>Hide overview on startup</summary>
       <description>Hide overview on startup, which would be shown by default at gnome startup.</description>
     </key>
+    <key type="i" name="drag-to-overview-delay">
+      <default>-1</default>
+      <summary>Delay before showing overview or previews when dragging over panel</summary>
+      <description>Number of milliseconds the pointer must hover over the panel while dragging before the overview or window previews are shown. Set to -1 to disable this behaviour entirely.</description>
+    </key>
+    <key type="b" name="drag-to-overview-preview">
+      <default>false</default>
+      <summary>Show window previews when dragging over app icons</summary>
+      <description>When dragging over an app icon, show the window preview popup instead of opening the overview.</description>
+    </key>
     <key type="b" name="group-apps">
       <default>true</default>
       <summary>Group applications</summary>

--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -62,6 +62,7 @@ const T3 = 'showDotsTimeout'
 const T4 = 'overviewWindowDragEndTimeout'
 const T5 = 'switchWorkspaceTimeout'
 const T6 = 'displayProperIndicatorTimeout'
+const T7 = 'xdndDragOverTimeout'
 
 //right padding defined for .overview-label in stylesheet.css
 const TITLE_RIGHT_PADDING = 8
@@ -432,7 +433,8 @@ export const TaskbarAppIcon = GObject.registerClass(
     _onAppIconHoverChanged() {
       if (
         !SETTINGS.get_boolean('show-window-previews') ||
-        (!this.window && !this._nWindows)
+        (!this.window && !this._nWindows) ||
+        this._inXdndDrag
       ) {
         return
       }
@@ -1710,24 +1712,103 @@ export const TaskbarAppIcon = GObject.registerClass(
       this._maybeUpdateNumberOverlay()
     }
 
+    cancelXdndDragTimeout() {
+      this._timeoutsHandler.remove(T7)
+      this._xdndActionFired = false
+      this._inXdndDrag = false
+      this.set_hover(false)
+    }
+
     handleDragOver(source) {
       if (source == Main.xdndHandler) {
-        this._previewMenu.close(true)
+        let delay = SETTINGS.get_int('drag-to-overview-delay')
 
-        if (!this._nWindows && !this.window)
-          return DND.DragMotionResult.MOVE_DROP
+        if (delay < 0) {
+          // Feature disabled: do nothing on drag, just let the drag pass through
+          return DND.DragMotionResult.CONTINUE
+        }
 
-        if (this._nWindows == 1 || this.window) {
-          this.window
-            ? Main.activateWindow(this.window)
-            : activateFirstWindow(this.app, this.monitor)
-        } else
-          this.dtpPanel.panelManager.showFocusedAppInOverview(this.app, true)
+        // Cancel any pending panel-level xdnd timeout since the cursor is now
+        // over this icon
+        this.dtpPanel.cancelXdndOverviewTimeout()
+
+        // Clear state on all other icons (hover highlight, timers, fired flags).
+        // The xdnd walk stops at the first MOVE_DROP result so the panel's
+        // cancelXdndDragTimeouts() is never reached when moving between icons.
+        // Pass `this` so our own fired flag and timer are not disturbed.
+        this.dtpPanel.taskbar.cancelXdndDragTimeouts(this)
+
+        // Simulate hover highlight as if the cursor were normally over the icon
+        // (XDnD grabs the pointer so Clutter never sets hover automatically).
+        // Set _inXdndDrag before set_hover so that _onAppIconHoverChanged
+        // doesn't call requestOpen — preview opening is managed by T7 below.
+        if (!this.hover) {
+          this._inXdndDrag = true
+          this.set_hover(true)
+        }
+
+        // Guard against re-firing when delay=0: once the action has run for
+        // this icon hover, don't restart it on every subsequent mouse-move event
+        if (!this._timeoutsHandler.getId(T7) && !this._xdndActionFired) {
+          this._timeoutsHandler.add([
+            T7,
+            delay,
+            () => {
+              this._xdndActionFired = true
+
+              if (!this._nWindows && !this.window) return
+
+              const usePreview = SETTINGS.get_boolean('drag-to-overview-preview')
+
+              if (usePreview) {
+                // If the preview is already open for a different icon, close it
+                // first. If it's already showing this icon, just enable drag
+                // mode, no need to close and re-open (which would cause a
+                // flicker animation).
+                if (this._previewMenu.currentAppIcon === this) {
+                  this._previewMenu._setDragMode(true)
+                } else {
+                  this._previewMenu.close(true)
+                  this._previewMenu.open(this, true)
+                }
+              } else {
+                // Not using preview: close any open preview popup first
+                this._previewMenu.close(true)
+
+                if (this._nWindows == 1 || this.window) {
+                  // No preview: activate the single window directly
+                  this.window
+                    ? Main.activateWindow(this.window)
+                    : activateFirstWindow(this.app, this.monitor)
+                } else {
+                  // No preview, multi-window: fall back to overview
+                  this.dtpPanel.panelManager.showFocusedAppInOverview(
+                    this.app,
+                    true,
+                  )
+                }
+              }
+            },
+          ])
+        }
 
         return DND.DragMotionResult.MOVE_DROP
       }
 
+      this._timeoutsHandler.remove(T7)
+      this._xdndActionFired = false
+      this._inXdndDrag = false
+      this.set_hover(false)
       return DND.DragMotionResult.CONTINUE
+    }
+
+    acceptDrop() {
+      // Cancel any pending xdnd drag timeout when a drop occurs on the icon
+      this._timeoutsHandler.remove(T7)
+      this._xdndActionFired = false
+      this._inXdndDrag = false
+      this.set_hover(false)
+      return false
     }
 
     getAppIconInterestingWindows(isolateMonitors) {

--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -447,6 +447,7 @@ export const TaskbarAppIcon = GObject.registerClass(
     }
 
     _onDestroy() {
+      this._disposed = true
       super._onDestroy()
 
       if (this._updateIconIdleId) {
@@ -1713,6 +1714,8 @@ export const TaskbarAppIcon = GObject.registerClass(
     }
 
     cancelXdndDragTimeout() {
+      if (this._disposed) return
+
       this._timeoutsHandler.remove(T7)
       this._xdndActionFired = false
       this._inXdndDrag = false
@@ -1728,21 +1731,21 @@ export const TaskbarAppIcon = GObject.registerClass(
           return DND.DragMotionResult.CONTINUE
         }
 
-        // Cancel any pending panel-level xdnd timeout since the cursor is now
-        // over this icon
-        this.dtpPanel.cancelXdndOverviewTimeout()
-
-        // Clear state on all other icons (hover highlight, timers, fired flags).
-        // The xdnd walk stops at the first MOVE_DROP result so the panel's
-        // cancelXdndDragTimeouts() is never reached when moving between icons.
-        // Pass `this` so our own fired flag and timer are not disturbed.
-        this.dtpPanel.taskbar.cancelXdndDragTimeouts(this)
-
         // Simulate hover highlight as if the cursor were normally over the icon
         // (XDnD grabs the pointer so Clutter never sets hover automatically).
         // Set _inXdndDrag before set_hover so that _onAppIconHoverChanged
         // doesn't call requestOpen — preview opening is managed by T7 below.
         if (!this.hover) {
+          // Cancel any pending panel-level xdnd timeout since the cursor is now
+          // over this icon
+          this.dtpPanel.cancelXdndOverviewTimeout()
+
+          // Clear state on all other icons (hover highlight, timers, fired flags).
+          // The xdnd walk stops at the first MOVE_DROP result so the panel's
+          // cancelXdndDragTimeouts() is never reached when moving between icons.
+          // Pass `this` so our own fired flag and timer are not disturbed.
+          this.dtpPanel.taskbar.cancelXdndDragTimeouts(this)
+
           this._inXdndDrag = true
           this.set_hover(true)
         }

--- a/src/panel.js
+++ b/src/panel.js
@@ -73,6 +73,7 @@ const T4 = 'showDesktopTimeout'
 const T5 = 'trackerFocusAppTimeout'
 const T6 = 'scrollPanelDelayTimeout'
 const T7 = 'waitPanelBoxAllocation'
+const T8 = 'dragToOverviewDelay'
 
 const MIN_PANEL_SIZE = 22
 
@@ -372,6 +373,39 @@ export const Panel = GObject.registerClass(
         ],
         [this.panel, 'scroll-event', this._onPanelMouseScroll.bind(this)],
         [Main.layoutManager, 'startup-complete', () => this._resetGeometry()],
+        [
+          Main.xdndHandler,
+          'drag-begin',
+          () => {
+            if (!this._xdndDragMonitor) {
+              this._xdndDragMonitor = {
+                dragMotion: (dragEvent) => {
+                  this._onXdndDragMotion(dragEvent)
+                  return DND.DragMotionResult.CONTINUE
+                },
+              }
+              DND.addDragMonitor(this._xdndDragMonitor)
+            }
+          },
+        ],
+        [
+          Main.xdndHandler,
+          'drag-end',
+          () => {
+            // Fires on both cursor-leave and button-release.
+            // Cancel any pending timeout and close any drag-opened preview,
+            // but do NOT reset _xdndPanelActionFired. Once the overview has
+            // been triggered for this drag it should not trigger again on
+            // re-entry (drag-end/drag-begin fire on every leave/enter, not
+            // just on a genuine new drag starting).
+            this._removeXdndDragMonitor()
+            this._timeoutsHandler.remove(T8)
+            // Clear simulated hover on all icons when the drag leaves/ends
+            this.taskbar.cancelXdndDragTimeouts()
+            let previewMenu = this.taskbar.previewMenu
+            if (previewMenu._dragMode) previewMenu.close(true)
+          },
+        ],
       )
 
       this._bindSettingsChanges()
@@ -417,6 +451,7 @@ export const Panel = GObject.registerClass(
     disable() {
       this.panelStyle.disable()
 
+      this._removeXdndDragMonitor()
       this._timeoutsHandler.destroy()
       this._signalsHandler.destroy()
 
@@ -523,11 +558,97 @@ export const Panel = GObject.registerClass(
         source == Main.xdndHandler &&
         Main.overview.shouldToggleByCornerOrButton()
       ) {
-        this.panelManager.showFocusedAppInOverview(null, true)
-        Main.overview.show()
+        let delay = SETTINGS.get_int('drag-to-overview-delay')
+
+        if (delay < 0) {
+          // Feature disabled: never open overview on drag
+          return DND.DragMotionResult.CONTINUE
+        }
+
+        // Only react when the cursor is over the taskbar area itself.
+        // Dragging over other panel elements (clock, system tray, activities
+        // button, padding, etc.) should not trigger the overview or previews.
+        const [x, y] = global.get_pointer()
+        const pickedActor = global.stage.get_actor_at_pos(
+          Clutter.PickMode.REACTIVE,
+          x,
+          y,
+        )
+        if (!this.taskbar.actor.contains(pickedActor)) {
+          // We're outside the taskbar (clock, system tray, etc.); cancel any
+          // pending T8 and icon-level timeouts but keep _xdndPanelActionFired
+          // so re-entering the taskbar does not re-trigger the overview.
+          this._timeoutsHandler.remove(T8)
+          this.taskbar.cancelXdndDragTimeouts()
+          return DND.DragMotionResult.CONTINUE
+        }
+
+        // Cancel any pending icon-level xdnd timeouts since the cursor is now
+        // over empty panel space
+        this.taskbar.cancelXdndDragTimeouts()
+
+        if (!this._timeoutsHandler.getId(T8) && !this._xdndPanelActionFired) {
+          this._timeoutsHandler.add([
+            T8,
+            delay,
+            () => {
+              this._xdndPanelActionFired = true
+              this.panelManager.showFocusedAppInOverview(null, true)
+              Main.overview.show()
+            },
+          ])
+        }
+      } else {
+        this._timeoutsHandler.remove(T8)
+        this._xdndPanelActionFired = false
       }
 
       return DND.DragMotionResult.CONTINUE
+    }
+
+    acceptDrop() {
+      // Cancel any pending drag-to-overview timeout when a drop occurs on the panel
+      this._timeoutsHandler.remove(T8)
+      this._xdndPanelActionFired = false
+      return false
+    }
+
+    _onXdndDragMotion(dragEvent) {
+      let previewMenu = this.taskbar.previewMenu
+      let pickedActor = global.stage.get_actor_at_pos(
+        Clutter.PickMode.REACTIVE,
+        dragEvent.x,
+        dragEvent.y,
+      )
+
+      // Check if the cursor is over any of our managed areas:
+      // the taskbar (which contains app icons), or the preview popup menu.
+      let isOverTaskbar = this.taskbar.actor.contains(pickedActor)
+      let isOverPreview =
+        previewMenu._dragMode && previewMenu.menu.contains(pickedActor)
+
+      if (!isOverTaskbar && !isOverPreview) {
+        // Cursor has moved away from both the taskbar and any drag-opened
+        // preview popup. Clear simulated hover on all icons.
+        this.taskbar.cancelXdndDragTimeouts()
+
+        // Also cancel any pending panel-level overview timeout
+        this._timeoutsHandler.remove(T8)
+
+        // Close any drag-opened preview popup
+        if (previewMenu._dragMode) previewMenu.close(true)
+      }
+    }
+
+    cancelXdndOverviewTimeout() {
+      this._timeoutsHandler.remove(T8)
+    }
+
+    _removeXdndDragMonitor() {
+      if (this._xdndDragMonitor) {
+        DND.removeDragMonitor(this._xdndDragMonitor)
+        this._xdndDragMonitor = null
+      }
     }
 
     getPosition() {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -2654,6 +2654,57 @@ const Preferences = class {
       Gio.SettingsBindFlags.DEFAULT,
     )
 
+    let dragToOverviewSwitch = this._builder.get_object('drag_to_overview_switch')
+    let dragToOverviewDelayRow = this._builder.get_object('drag_to_overview_delay_row')
+    let dragToOverviewDelaySpin = this._builder.get_object(
+      'drag_to_overview_delay_spinbutton',
+    )
+    let dragToOverviewPreviewRow = this._builder.get_object(
+      'drag_to_overview_preview_row',
+    )
+
+    let updateDragToOverviewUi = () => {
+      let delay = this._settings.get_int('drag-to-overview-delay')
+      let enabled = delay >= 0
+
+      dragToOverviewSwitch.set_active(enabled)
+      dragToOverviewDelayRow.set_sensitive(enabled)
+      dragToOverviewPreviewRow.set_sensitive(enabled)
+
+      if (enabled) dragToOverviewDelaySpin.set_value(delay)
+    }
+
+    updateDragToOverviewUi()
+
+    dragToOverviewSwitch.connect('notify::active', () => {
+      if (dragToOverviewSwitch.get_active()) {
+        // Restore last positive delay (or default 300ms)
+        let current = this._settings.get_int('drag-to-overview-delay')
+        this._settings.set_int(
+          'drag-to-overview-delay',
+          current >= 0 ? current : 300,
+        )
+      } else {
+        this._settings.set_int('drag-to-overview-delay', -1)
+      }
+      updateDragToOverviewUi()
+    })
+
+    dragToOverviewDelaySpin.connect('value-changed', () => {
+      if (dragToOverviewSwitch.get_active())
+        this._settings.set_int(
+          'drag-to-overview-delay',
+          dragToOverviewDelaySpin.get_value_as_int(),
+        )
+    })
+
+    this._settings.bind(
+      'drag-to-overview-preview',
+      this._builder.get_object('drag_to_overview_preview_switch'),
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    )
+
     this._settings.bind(
       'group-apps',
       this._builder.get_object('group_apps_switch'),

--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -708,6 +708,12 @@ export const Taskbar = class extends EventEmitter {
         .forEach((fav) => fav._container[cssFuncName]('favorite'))
   }
 
+  cancelXdndDragTimeouts(exceptIcon) {
+    this._getAppIcons().forEach((icon) => {
+      if (icon !== exceptIcon) icon.cancelXdndDragTimeout()
+    })
+  }
+
   handleIsolatedWorkspaceSwitch() {
     this._shownInitially = this.isGroupApps
     this._queueRedisplay()

--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -710,7 +710,9 @@ export const Taskbar = class extends EventEmitter {
 
   cancelXdndDragTimeouts(exceptIcon) {
     this._getAppIcons().forEach((icon) => {
-      if (icon !== exceptIcon) icon.cancelXdndDragTimeout()
+      if (icon && icon !== exceptIcon && !icon._disposed) {
+        icon.cancelXdndDragTimeout()
+      }
     })
   }
 

--- a/src/windowPreview.js
+++ b/src/windowPreview.js
@@ -20,6 +20,7 @@ import Clutter from 'gi://Clutter'
 import GLib from 'gi://GLib'
 import Graphene from 'gi://Graphene'
 import * as Main from 'resource:///org/gnome/shell/ui/main.js'
+import * as DND from 'resource:///org/gnome/shell/ui/dnd.js'
 import Meta from 'gi://Meta'
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js'
 import St from 'gi://St'
@@ -207,6 +208,7 @@ export const PreviewMenu = GObject.registerClass(
 
         this._setReactive(true)
         this._setOpenedState(true)
+        this._setDragMode(preventCloseWindow)
       }
     }
 
@@ -223,6 +225,7 @@ export const PreviewMenu = GObject.registerClass(
       }
 
       this._setReactive(false)
+      this._setDragMode(false)
       this.currentAppIcon = null
     }
 
@@ -392,6 +395,15 @@ export const PreviewMenu = GObject.registerClass(
       this._box.add_child(preview)
       preview.adjustOnStage()
       preview.assignWindow(window, this.opened)
+
+      if (this._dragMode) preview._setXdndDelegate(true)
+    }
+
+    _setDragMode(enabled) {
+      this._dragMode = !!enabled
+      this._box
+        .get_children()
+        .forEach((preview) => preview._setXdndDelegate(this._dragMode))
     }
 
     _setShouldDisplayWorkspaces(windows) {
@@ -1060,6 +1072,26 @@ export const Preview = GObject.registerClass(
       this._previewMenu.endPeekHere()
       this._previewMenu.close()
       Main.activateWindow(this.window)
+    }
+
+    _setXdndDelegate(enabled) {
+      if (enabled) {
+        // Expose handleDragOver and acceptDrop so the GNOME Shell DND system
+        // can find this preview as a drop target when an external (XDnD) drag
+        // passes over it
+        this._delegate = {
+          handleDragOver: (source) => {
+            if (source === Main.xdndHandler && this.window) {
+              Main.activateWindow(this.window)
+              return DND.DragMotionResult.MOVE_DROP
+            }
+            return DND.DragMotionResult.CONTINUE
+          },
+          acceptDrop: () => false,
+        }
+      } else {
+        delete this._delegate
+      }
     }
 
     _onDestroy() {

--- a/src/windowPreview.js
+++ b/src/windowPreview.js
@@ -20,6 +20,7 @@ import Clutter from 'gi://Clutter'
 import GLib from 'gi://GLib'
 import Graphene from 'gi://Graphene'
 import * as Main from 'resource:///org/gnome/shell/ui/main.js'
+import * as DND from 'resource:///org/gnome/shell/ui/dnd.js'
 import Meta from 'gi://Meta'
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js'
 import St from 'gi://St'
@@ -208,6 +209,7 @@ export const PreviewMenu = GObject.registerClass(
 
         this._setReactive(true)
         this._setOpenedState(true)
+        this._setDragMode(preventCloseWindow)
       }
     }
 
@@ -224,6 +226,7 @@ export const PreviewMenu = GObject.registerClass(
       }
 
       this._setReactive(false)
+      this._setDragMode(false)
       this.currentAppIcon = null
     }
 
@@ -393,6 +396,15 @@ export const PreviewMenu = GObject.registerClass(
       this._box.add_child(preview)
       preview.adjustOnStage()
       preview.assignWindow(window, this.opened)
+
+      if (this._dragMode) preview._setXdndDelegate(true)
+    }
+
+    _setDragMode(enabled) {
+      this._dragMode = !!enabled
+      this._box
+        .get_children()
+        .forEach((preview) => preview._setXdndDelegate(this._dragMode))
     }
 
     _setShouldDisplayWorkspaces(windows) {
@@ -1068,6 +1080,26 @@ export const Preview = GObject.registerClass(
       this._previewMenu.endPeekHere()
       this._previewMenu.close()
       Main.activateWindow(this.window)
+    }
+
+    _setXdndDelegate(enabled) {
+      if (enabled) {
+        // Expose handleDragOver and acceptDrop so the GNOME Shell DND system
+        // can find this preview as a drop target when an external (XDnD) drag
+        // passes over it
+        this._delegate = {
+          handleDragOver: (source) => {
+            if (source === Main.xdndHandler && this.window) {
+              Main.activateWindow(this.window)
+              return DND.DragMotionResult.MOVE_DROP
+            }
+            return DND.DragMotionResult.CONTINUE
+          },
+          acceptDrop: () => false,
+        }
+      } else {
+        delete this._delegate
+      }
     }
 
     _onDestroy() {

--- a/ui/SettingsBehavior.ui
+++ b/ui/SettingsBehavior.ui
@@ -116,6 +116,52 @@
       </object>
     </child>
     <child>
+      <object class="AdwPreferencesGroup" id="behavior_group_drag">
+        <property name="title" translatable="yes">Drag</property>
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Show overview or previews when dragging over panel</property>
+            <property name="subtitle" translatable="yes">Disable to prevent accidental activation while dragging across the panel</property>
+            <child>
+              <object class="GtkSwitch" id="drag_to_overview_switch">
+                <property name="valign">center</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwActionRow" id="drag_to_overview_delay_row">
+            <property name="title" translatable="yes">Drag hover delay (ms)</property>
+            <property name="subtitle" translatable="yes">Milliseconds the pointer must remain over the panel before the overview or previews open</property>
+            <child>
+              <object class="GtkSpinButton" id="drag_to_overview_delay_spinbutton">
+                <property name="valign">center</property>
+                <property name="adjustment">
+                  <object class="GtkAdjustment">
+                    <property name="lower">0</property>
+                    <property name="upper">5000</property>
+                    <property name="step-increment">50</property>
+                    <property name="page-increment">250</property>
+                  </object>
+                </property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwActionRow" id="drag_to_overview_preview_row">
+            <property name="title" translatable="yes">Show window previews when dragging over app icons</property>
+            <property name="subtitle" translatable="yes">Show the window preview popup instead of opening the overview when dragging over an app icon</property>
+            <child>
+              <object class="GtkSwitch" id="drag_to_overview_preview_switch">
+                <property name="valign">center</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
       <object class="AdwPreferencesGroup" id="behavior_group_isolate">
         <property name="title" translatable="yes">Isolate</property>
         <child>


### PR DESCRIPTION
Fixes https://github.com/home-sweet-gnome/dash-to-panel/issues/2087 and I think also fixes https://github.com/home-sweet-gnome/dash-to-panel/issues/2407 (the hot corner behaviour mentioned in there is driven by separate logic which is unaffected by these changes).

## Problem

When performing an external drag-and-drop (e.g. dragging selected text or a file from one application to another while crossing the panel), any mouse contact with the panel would instantly trigger the GNOME Overview. This makes cross-monitor drag-and-drop painful, leaving the user stranded in the overview mid-drag with no clear path to their intended drop target.

## Steps to reproduce

- I use a multi-monitor setup with dash-to-panel set on the left edge of the right monitor (so the dock is between both monitors), but it can be reproduced on a single monitor
- Open two Firefox windows or Text Editor windows
- Select some text in the apps, then drag it through the panel (anywhere, not even over any app icons and through an empty portion of the dock, not waiting on the dock at all, very rapidly passing it) to drop it in another window
- Overview is triggered _instantly_ as the mouse collides with the panel

## Changes

Adds three new settings to control the behavior of dragging an item over the panel.

*   Adds a toggle to fully disable drag from having any effect when crossing the panel if it's generally undesirable.
*   Adds a configurable delay (in milliseconds) before activating the hover action (either preview or overview) during a drag operation, if dragging is enabled, helping prevent accidental activation if just passing through the panel without having the cursor sit on the panel.
*   Adds new functionality to show window previews if window previews are enabled (which is more streamlined), instead of opening the overview (which is quite intrusive causing all windows on all monitors to collapse into the overview)

<img width="571" height="300" alt="image" src="https://github.com/user-attachments/assets/53baf953-8bbd-47df-9974-4da728a676af" />

<img width="571" height="300" alt="image" src="https://github.com/user-attachments/assets/32720fe4-f68f-4718-9417-74d7af574cc6" />


## Demo


https://github.com/user-attachments/assets/35d6d632-e786-4dc2-8c8c-317246566d13

- I have two text edit windows open, to demo dragging between multiple windows of the same app.
- 0:00-0:10 I show the behaviour with dragging enabled, with 0ms delay, and using previews instead of overview. I select and drag some text from one window, then show that a given window can be focused via the preview panel while still dragging the piece of text, finally releasing the mouse to drop the held text into the second window.
- 0:11-0:20 Then, dragging text again, I show that the hover style appears on other apps (ones not running) as you'd expect, as it does when you don't drag; but releasing the mouse on a non-running app does nothing. Just feels better to show the hover style because it's more consistent overall. Also shows that the hover style goes away when dragging off the panel (it was a bug that needed resolving while developing this).
- 0:21-0:35 Then, I go to the settings, I increase the delay to 550ms, drag some text, and show that there's a longer delay before the preview appears. The delay helps to ignore accidental preview pop-ins if just dragging through the panel on a multi-monitor setup.
- 0:36-0:46 Then I turn off dragging altogether, (which also disables the other two settings) and show that nothing happens when dragging over the panel, including no hover styles.
- 0:47-1:04 Then I turn back on dragging but turn off preview mode (which means it opens the overview instead) and show that behaviour; with a 300ms delay it requires sitting on the app icon for a moment then overview appears. I show that overview only shows for apps with multiple windows (it doesn't for the settings app, only the text edit app since it has two windows), then I drag onto one of the two text windows and wait until overview animates and focuses that window.


## Technical Breakdown

Two new GSettings keys:

- `drag-to-overview-delay` (int, default `-1`): ms delay before activation; `-1` disables entirely
- `drag-to-overview-preview` (bool, default `false`): show window preview popup instead of overview

### `appIcons.js`
- **`handleDragOver`**: Replaces the old immediate-activation logic with a delay-gated timeout (`T7`). When the xdnd source is detected: cancels panel-level timeout, clears other icons' state via `cancelXdndDragTimeouts(this)`, simulates hover highlight (Clutter won't set it during XDnD pointer grab), and starts a one-shot timer. On fire, either opens preview popup in drag mode or falls back to activate-window/show-overview depending on window count and the preview setting.
- **`_onAppIconHoverChanged`**: Bails out when `_inXdndDrag` is set, preventing the normal preview `requestOpen` path from racing with the T7-managed open.
- **`cancelXdndDragTimeout`**: Resets T7, `_xdndActionFired`, `_inXdndDrag`, and hover state. Used as the single cleanup entry point per icon.
- **`acceptDrop`**: Cleans up xdnd state on drop.

### `panel.js`
- **`handleDragOver`**: Gated by `drag-to-overview-delay`. Uses `get_actor_at_pos` to scope activation to the taskbar area only (ignoring clock, systray, activities, etc.). Manages a panel-level timeout (`T8`) guarded by `_xdndPanelActionFired` to prevent re-triggering on cursor re-entry within the same drag session.
- **`drag-begin` / `drag-end`**: Registers/removes a `DND.addDragMonitor` for the xdnd session. This is needed because `XdndHandler._onPositionChanged` only calls `handleDragOver` on actors under the cursor — when the cursor moves off the panel to the desktop (still within GNOME Shell), no panel/icon code runs to clean up simulated hover or close previews.
- **`_onXdndDragMotion`**: The drag monitor callback. Picks the actor under cursor and checks if it's within `taskbar.actor` or the drag-mode `previewMenu.menu`. If neither, clears all icon hover state and closes any drag-opened preview.
- **`acceptDrop`**: Cleans up panel-level xdnd state on drop.

### `taskbar.js`
- **`cancelXdndDragTimeouts(exceptIcon)`**: Iterates all app icons calling `cancelXdndDragTimeout()`, optionally skipping one icon (the caller, to avoid clearing its own in-progress state).

### `windowPreview.js`
- **`_setDragMode(enabled)`**: Toggles `_dragMode` on the `PreviewMenu` and calls `_setXdndDelegate` on all child previews. Activated when the preview is opened via drag (`preventCloseWindow=true`), cleared on close.
- **`_setXdndDelegate(enabled)`**: Assigns/removes a `_delegate` on each `Preview` actor with `handleDragOver`/`acceptDrop`, making previews visible as drop targets to the GNOME Shell DND system during xdnd. `handleDragOver` activates the hovered window.

### `prefs.js` / `SettingsBehavior.ui`
- New "Drag" preferences group with enable switch, delay spinner (0–5000ms), and preview toggle. The switch maps `-1`/`≥0` to the single `drag-to-overview-delay` key.

## Disclosure

Used Github Copilot + Claude Sonnet 4.6 to make the code changes, tested locally by hand with `dbus-run-session -- gnome-shell --devkit --wayland`, then had Claude Opus 4.6 do a final review pass and fix one bug I couldn't get Sonnet to fix in reasonable time.