### PR TITLE
fix: panel is hidden unexpectedly after resume from suspend or lock

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -141,7 +141,7 @@ export default class DashToPanelExtension extends Extension {
     }
 
     // disable ubuntu dock if present
-    if (Main.extensionManager._extensionOrder.indexOf(UBUNTU_DOCK_UUID) >= 0) {
+    if (Main.extensionManager._extensionOrder.indexOf(UBUNTU_DOCK_UUID) >= 0 && !SETTINGS.get_boolean('stockgs-keep-dash')) {
       let disabled = global.settings.get_strv('disabled-extensions')
 
       if (disabled.indexOf(UBUNTU_DOCK_UUID) < 0) {


### PR DESCRIPTION
close #2461

Each time resuming from suspend or lock, the `enable` method is executed, which then adds the "Dock" option switch into the disabled list, causing the original GNOME Shell dash to be hidden.

By adding an additional conditional check, we can ensure that when the "Keep original GNOME Shell dash" option is enabled, the dock is not incorrectly hidden.

Additionally, I think the dock visibility could be fully controlled by the options in GNOME Settings. The "Keep original GNOME Shell dash" option and the logic for disabling the GNOME Settings Dock option should be removed.