### PR TITLE
fix: Implement startupPreparedHandler for overview control

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -38,7 +38,7 @@ const UBUNTU_DOCK_UUID = 'ubuntu-dock@ubuntu.com'
 
 let panelManager
 let startupCompleteHandler
-let startupPreparedHandler
+let originalPrepareStartupAnimation
 let ubuntuDockDelayId = 0
 
 export let DTP_EXTENSION = null
@@ -121,32 +121,31 @@ export default class DashToPanelExtension extends Extension {
 
       // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral in
       // Layout._loadBackground that previously held _prepareStartupAnimation
-      // until after the extension-enable chain had run. Without it, the
-      // startup-animation chain and the extension-enable chain are
-      // independent promise chains with no guaranteed ordering.
+      // until the extension-enable chain had run. _doStartupAnimation now
+      // reads Main.sessionMode.hasOverview at two awaits with no ordering
+      // guarantee against extension init - first in _prepareStartupAnimation
+      // (decides uiGroup pre-scale), then in _startupAnimationSession
+      // (decides the animation branch).
       //
-      // _doStartupAnimation reads Main.sessionMode.hasOverview twice:
-      //   1. layout.js _prepareStartupAnimation (decides whether to
-      //      pre-scale uiGroup for the grow-out animation)
-      //   2. layout.js _startupAnimationSession (decides whether to call
-      //      Main.overview.runStartupAnimation)
-      //
-      // 'startup-prepared' fires synchronously between those two reads.
-      // The synchronous assignment above often wins both races on faster
-      // hardware, but on slower setups it can lose the first one. The
-      // handler below is a second line of defense for the second read.
-      //
-      // Defensive: disconnect any previous handler before reconnecting,
-      // in case enable() runs again before startup-complete fired.
-      if (startupPreparedHandler) {
-        Main.layoutManager.disconnect(startupPreparedHandler)
-      }
-      startupPreparedHandler = Main.layoutManager.connect(
-        'startup-prepared',
-        () => {
+      // Wrapping _prepareStartupAnimation lets us re-assert hasOverview
+      // synchronously, before either read happens. The wrapper restores
+      // itself on first call so we don't keep monkey-patching shell
+      // internals longer than necessary.
+      if (
+        Config.PACKAGE_VERSION >= '50' &&
+        !originalPrepareStartupAnimation &&
+        typeof Main.layoutManager._prepareStartupAnimation === 'function'
+      ) {
+        originalPrepareStartupAnimation =
+          Main.layoutManager._prepareStartupAnimation
+        Main.layoutManager._prepareStartupAnimation = function (...args) {
           Main.sessionMode.hasOverview = false
-        },
-      )
+          Main.layoutManager._prepareStartupAnimation =
+            originalPrepareStartupAnimation
+          originalPrepareStartupAnimation = null
+          return Main.layoutManager._prepareStartupAnimation.apply(this, args)
+        }
+      }
 
       startupCompleteHandler = Main.layoutManager.connect(
         'startup-complete',
@@ -203,9 +202,12 @@ export default class DashToPanelExtension extends Extension {
 
     AppIcons.resetRecentlyClickedApp()
 
-    if (startupPreparedHandler) {
-      Main.layoutManager.disconnect(startupPreparedHandler)
-      startupPreparedHandler = null
+    // Restore the wrapper if _prepareStartupAnimation never ran (i.e.
+    // extension disabled before login finished, unusual but possible).
+    if (originalPrepareStartupAnimation) {
+      Main.layoutManager._prepareStartupAnimation =
+        originalPrepareStartupAnimation
+      originalPrepareStartupAnimation = null
     }
 
     if (startupCompleteHandler) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -119,22 +119,49 @@ export default class DashToPanelExtension extends Extension {
     ) {
       Main.sessionMode.hasOverview = false
 
-      // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral that
-      // previously delayed the startup animation until after extensions
-      // had loaded. As a result, _startupAnimationSession() may read
-      // Main.sessionMode.hasOverview before our synchronous assignment
-      // above takes effect (the animation chain and extension-enable
-      // chain are concurrent promises, with no guaranteed order).
+      // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral in
+      // Layout._loadBackground that previously held _prepareStartupAnimation
+      // until after the extension-enable chain had run. Without it, the
+      // startup-animation chain and the extension-enable chain are
+      // independent promise chains with no guaranteed ordering.
       //
-      // 'startup-prepared' is emitted at the end of
-      // _prepareStartupAnimation, synchronously, BEFORE _startupAnimation
-      // reads hasOverview. Re-asserting the value in this handler closes
-      // the race window. This is harmless on older versions where the
-      // synchronous assignment was already enough.
+      // _doStartupAnimation reads Main.sessionMode.hasOverview twice:
+      //   1. layout.js _prepareStartupAnimation (decides whether to
+      //      pre-scale uiGroup for the grow-out animation)
+      //   2. layout.js _startupAnimationSession (decides whether to call
+      //      Main.overview.runStartupAnimation)
+      //
+      // 'startup-prepared' fires synchronously between those two reads.
+      // The synchronous assignment above often wins both races on faster
+      // hardware, but on slower setups it can lose the first one. The
+      // handler below is a second line of defense for the second read,
+      // and also catches the case where the overview animation has
+      // already started.
+      //
+      // Defensive: disconnect any previous handler before reconnecting,
+      // in case enable() runs again before startup-complete fired.
+      if (startupPreparedHandler) {
+        Main.layoutManager.disconnect(startupPreparedHandler)
+      }
       startupPreparedHandler = Main.layoutManager.connect(
         'startup-prepared',
         () => {
           Main.sessionMode.hasOverview = false
+
+          // If we lost the first race and Overview.runStartupAnimation
+          // is already in flight, request a hide now. The shell's own
+          // bail-out path in OverviewControls.runStartupAnimation
+          // (overview.js, gnome-shell 50: "Overview got hidden during
+          // startup animation") will short-circuit cleanly when it sees
+          // _shownState != SHOWING after its inner await resolves. This
+          // is preferable to mutating _stateAdjustment / _shown / etc.
+          // directly, which couples us to private overview internals.
+          if (
+            Config.PACKAGE_VERSION >= '50' &&
+            (Main.overview.visible || Main.overview._shown)
+          ) {
+            Main.overview.hide()
+          }
         },
       )
 
@@ -142,30 +169,6 @@ export default class DashToPanelExtension extends Extension {
         'startup-complete',
         () => {
           Main.sessionMode.hasOverview = this._realHasOverview
-
-          // Defensive fallback: if the overview did get shown despite
-          // our efforts (e.g. _startupAnimation already read hasOverview
-          // as true before we could intervene), force it closed. We use
-          // the controls' state adjustment to skip the hide animation
-          // and avoid a visible flash. See dash-to-dock for the same
-          // technique against the same race.
-          if (Config.PACKAGE_VERSION >= '50' && Main.overview.visible) {
-            try {
-              const controls = Main.overview._overview?.controls
-              if (controls?._stateAdjustment) {
-                // 0 == OverviewControls.ControlsState.HIDDEN
-                controls._stateAdjustment.value = 0
-              }
-              Main.overview._shown = false
-              Main.overview._visible = false
-              Main.overview._visibleTarget = false
-              Main.layoutManager.hideOverview()
-            } catch (e) {
-              // Last resort: animated hide, which produces the visible
-              // flash but is better than a stuck overview.
-              Main.overview.hide()
-            }
-          }
         },
       )
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -134,9 +134,7 @@ export default class DashToPanelExtension extends Extension {
       // 'startup-prepared' fires synchronously between those two reads.
       // The synchronous assignment above often wins both races on faster
       // hardware, but on slower setups it can lose the first one. The
-      // handler below is a second line of defense for the second read,
-      // and also catches the case where the overview animation has
-      // already started.
+      // handler below is a second line of defense for the second read.
       //
       // Defensive: disconnect any previous handler before reconnecting,
       // in case enable() runs again before startup-complete fired.
@@ -147,21 +145,6 @@ export default class DashToPanelExtension extends Extension {
         'startup-prepared',
         () => {
           Main.sessionMode.hasOverview = false
-
-          // If we lost the first race and Overview.runStartupAnimation
-          // is already in flight, request a hide now. The shell's own
-          // bail-out path in OverviewControls.runStartupAnimation
-          // (overview.js, gnome-shell 50: "Overview got hidden during
-          // startup animation") will short-circuit cleanly when it sees
-          // _shownState != SHOWING after its inner await resolves. This
-          // is preferable to mutating _stateAdjustment / _shown / etc.
-          // directly, which couples us to private overview internals.
-          if (
-            Config.PACKAGE_VERSION >= '50' &&
-            (Main.overview.visible || Main.overview._shown)
-          ) {
-            Main.overview.hide()
-          }
         },
       )
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -38,7 +38,6 @@ const UBUNTU_DOCK_UUID = 'ubuntu-dock@ubuntu.com'
 
 let panelManager
 let startupCompleteHandler
-let originalPrepareStartupAnimation
 let ubuntuDockDelayId = 0
 
 export let DTP_EXTENSION = null
@@ -55,40 +54,6 @@ export default class DashToPanelExtension extends Extension {
     super(metadata)
 
     this._realHasOverview = Main.sessionMode.hasOverview
-
-    // Install the startup-overview override as early as possible.
-    // GNOME 50's _doStartupAnimation runs concurrently with extension
-    // load; if we wait until enable() (which has awaits before any of
-    // its real work), _prepareStartupAnimation may already have fired
-    // and the overview will be visible at login.
-    //
-    // The constructor runs synchronously the moment GNOME Shell loads
-    // the extension module, before any await yields control back to
-    // _doStartupAnimation. Doing it here is the earliest hook we get.
-    if (
-      Config.PACKAGE_VERSION >= '50' &&
-      Main.layoutManager._startingUp &&
-      this.getSettings('org.gnome.shell.extensions.dash-to-panel').get_boolean(
-        'hide-overview-on-startup',
-      )
-    ) {
-      Main.sessionMode.hasOverview = false
-
-      if (
-        !originalPrepareStartupAnimation &&
-        typeof Main.layoutManager._prepareStartupAnimation === 'function'
-      ) {
-        originalPrepareStartupAnimation =
-          Main.layoutManager._prepareStartupAnimation
-        Main.layoutManager._prepareStartupAnimation = function (...args) {
-          Main.sessionMode.hasOverview = false
-          Main.layoutManager._prepareStartupAnimation =
-            originalPrepareStartupAnimation
-          originalPrepareStartupAnimation = null
-          return Main.layoutManager._prepareStartupAnimation.apply(this, args)
-        }
-      }
-    }
 
     //create an object that persists until gnome-shell is restarted, even if the extension is disabled
     PERSISTENTSTORAGE = {}
@@ -147,20 +112,35 @@ export default class DashToPanelExtension extends Extension {
       'hide-overview-on-startup',
     )
 
-    if (
-      SETTINGS.get_boolean('hide-overview-on-startup') &&
-      Main.layoutManager._startingUp
-    ) {
-      // Restore hasOverview to its real value once startup completes.
-      // (The wrapper installed in the constructor handles forcing
-      // hasOverview=false during _prepareStartupAnimation; this handler
-      // just undoes our temporary override afterwards.)
-      startupCompleteHandler = Main.layoutManager.connect(
-        'startup-complete',
-        () => {
-          Main.sessionMode.hasOverview = this._realHasOverview
-        },
-      )
+    if (SETTINGS.get_boolean('hide-overview-on-startup')) {
+      Main.sessionMode.hasOverview = false
+
+      // GNOME 50 changed extension load timing - on at least some
+      // hardware, dash-to-panel's enable() runs after the shell startup
+      // animation has fully completed (Main.layoutManager._startingUp
+      // is already false and Main.overview._shownState is already
+      // SHOWN). The previous gate on _startingUp meant this branch did
+      // nothing in that case. Drop the gate and act on actual state:
+      // if the overview is showing when we load, hide it.
+      if (Main.layoutManager._startingUp) {
+        // Still in startup - hide on completion as before. The shell's
+        // _startupAnimationComplete fires startup-complete after the
+        // cover pane is destroyed, so a normal hide() runs cleanly.
+        startupCompleteHandler = Main.layoutManager.connect(
+          'startup-complete',
+          () => {
+            Main.sessionMode.hasOverview = this._realHasOverview
+            if (Config.PACKAGE_VERSION >= '50') Main.overview.hide()
+          },
+        )
+      } else {
+        // Startup is already done. Restore hasOverview and hide if
+        // currently shown.
+        Main.sessionMode.hasOverview = this._realHasOverview
+        if (Main.overview.visible || Main.overview._shown) {
+          Main.overview.hide()
+        }
+      }
     }
 
     this.enableGlobalStyles()
@@ -209,14 +189,6 @@ export default class DashToPanelExtension extends Extension {
     this.disableGlobalStyles()
 
     AppIcons.resetRecentlyClickedApp()
-
-    // Restore the wrapper if _prepareStartupAnimation never ran (i.e.
-    // extension disabled before login finished, unusual but possible).
-    if (originalPrepareStartupAnimation) {
-      Main.layoutManager._prepareStartupAnimation =
-        originalPrepareStartupAnimation
-      originalPrepareStartupAnimation = null
-    }
 
     if (startupCompleteHandler) {
       Main.layoutManager.disconnect(startupCompleteHandler)

--- a/src/extension.js
+++ b/src/extension.js
@@ -56,6 +56,40 @@ export default class DashToPanelExtension extends Extension {
 
     this._realHasOverview = Main.sessionMode.hasOverview
 
+    // Install the startup-overview override as early as possible.
+    // GNOME 50's _doStartupAnimation runs concurrently with extension
+    // load; if we wait until enable() (which has awaits before any of
+    // its real work), _prepareStartupAnimation may already have fired
+    // and the overview will be visible at login.
+    //
+    // The constructor runs synchronously the moment GNOME Shell loads
+    // the extension module, before any await yields control back to
+    // _doStartupAnimation. Doing it here is the earliest hook we get.
+    if (
+      Config.PACKAGE_VERSION >= '50' &&
+      Main.layoutManager._startingUp &&
+      this.getSettings('org.gnome.shell.extensions.dash-to-panel').get_boolean(
+        'hide-overview-on-startup',
+      )
+    ) {
+      Main.sessionMode.hasOverview = false
+
+      if (
+        !originalPrepareStartupAnimation &&
+        typeof Main.layoutManager._prepareStartupAnimation === 'function'
+      ) {
+        originalPrepareStartupAnimation =
+          Main.layoutManager._prepareStartupAnimation
+        Main.layoutManager._prepareStartupAnimation = function (...args) {
+          Main.sessionMode.hasOverview = false
+          Main.layoutManager._prepareStartupAnimation =
+            originalPrepareStartupAnimation
+          originalPrepareStartupAnimation = null
+          return Main.layoutManager._prepareStartupAnimation.apply(this, args)
+        }
+      }
+    }
+
     //create an object that persists until gnome-shell is restarted, even if the extension is disabled
     PERSISTENTSTORAGE = {}
   }
@@ -117,36 +151,10 @@ export default class DashToPanelExtension extends Extension {
       SETTINGS.get_boolean('hide-overview-on-startup') &&
       Main.layoutManager._startingUp
     ) {
-      Main.sessionMode.hasOverview = false
-
-      // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral in
-      // Layout._loadBackground that previously held _prepareStartupAnimation
-      // until the extension-enable chain had run. _doStartupAnimation now
-      // reads Main.sessionMode.hasOverview at two awaits with no ordering
-      // guarantee against extension init - first in _prepareStartupAnimation
-      // (decides uiGroup pre-scale), then in _startupAnimationSession
-      // (decides the animation branch).
-      //
-      // Wrapping _prepareStartupAnimation lets us re-assert hasOverview
-      // synchronously, before either read happens. The wrapper restores
-      // itself on first call so we don't keep monkey-patching shell
-      // internals longer than necessary.
-      if (
-        Config.PACKAGE_VERSION >= '50' &&
-        !originalPrepareStartupAnimation &&
-        typeof Main.layoutManager._prepareStartupAnimation === 'function'
-      ) {
-        originalPrepareStartupAnimation =
-          Main.layoutManager._prepareStartupAnimation
-        Main.layoutManager._prepareStartupAnimation = function (...args) {
-          Main.sessionMode.hasOverview = false
-          Main.layoutManager._prepareStartupAnimation =
-            originalPrepareStartupAnimation
-          originalPrepareStartupAnimation = null
-          return Main.layoutManager._prepareStartupAnimation.apply(this, args)
-        }
-      }
-
+      // Restore hasOverview to its real value once startup completes.
+      // (The wrapper installed in the constructor handles forcing
+      // hasOverview=false during _prepareStartupAnimation; this handler
+      // just undoes our temporary override afterwards.)
       startupCompleteHandler = Main.layoutManager.connect(
         'startup-complete',
         () => {

--- a/src/extension.js
+++ b/src/extension.js
@@ -38,6 +38,7 @@ const UBUNTU_DOCK_UUID = 'ubuntu-dock@ubuntu.com'
 
 let panelManager
 let startupCompleteHandler
+let startupPreparedHandler
 let ubuntuDockDelayId = 0
 
 export let DTP_EXTENSION = null
@@ -117,15 +118,54 @@ export default class DashToPanelExtension extends Extension {
       Main.layoutManager._startingUp
     ) {
       Main.sessionMode.hasOverview = false
+
+      // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral that
+      // previously delayed the startup animation until after extensions
+      // had loaded. As a result, _startupAnimationSession() may read
+      // Main.sessionMode.hasOverview before our synchronous assignment
+      // above takes effect (the animation chain and extension-enable
+      // chain are concurrent promises, with no guaranteed order).
+      //
+      // 'startup-prepared' is emitted at the end of
+      // _prepareStartupAnimation, synchronously, BEFORE _startupAnimation
+      // reads hasOverview. Re-asserting the value in this handler closes
+      // the race window. This is harmless on older versions where the
+      // synchronous assignment was already enough.
+      startupPreparedHandler = Main.layoutManager.connect(
+        'startup-prepared',
+        () => {
+          Main.sessionMode.hasOverview = false
+        },
+      )
+
       startupCompleteHandler = Main.layoutManager.connect(
         'startup-complete',
         () => {
           Main.sessionMode.hasOverview = this._realHasOverview
 
-          // the extension initialization timing changed in g-s version 50 and the startup animation
-          // is already running when the extension init code is executed. Since there is no way to
-          // prevent the animation from running, hide the overview when it completes
-          if (Config.PACKAGE_VERSION >= '50') Main.overview.hide()
+          // Defensive fallback: if the overview did get shown despite
+          // our efforts (e.g. _startupAnimation already read hasOverview
+          // as true before we could intervene), force it closed. We use
+          // the controls' state adjustment to skip the hide animation
+          // and avoid a visible flash. See dash-to-dock for the same
+          // technique against the same race.
+          if (Config.PACKAGE_VERSION >= '50' && Main.overview.visible) {
+            try {
+              const controls = Main.overview._overview?.controls
+              if (controls?._stateAdjustment) {
+                // 0 == OverviewControls.ControlsState.HIDDEN
+                controls._stateAdjustment.value = 0
+              }
+              Main.overview._shown = false
+              Main.overview._visible = false
+              Main.overview._visibleTarget = false
+              Main.layoutManager.hideOverview()
+            } catch (e) {
+              // Last resort: animated hide, which produces the visible
+              // flash but is better than a stuck overview.
+              Main.overview.hide()
+            }
+          }
         },
       )
     }
@@ -176,6 +216,11 @@ export default class DashToPanelExtension extends Extension {
     this.disableGlobalStyles()
 
     AppIcons.resetRecentlyClickedApp()
+
+    if (startupPreparedHandler) {
+      Main.layoutManager.disconnect(startupPreparedHandler)
+      startupPreparedHandler = null
+    }
 
     if (startupCompleteHandler) {
       Main.layoutManager.disconnect(startupCompleteHandler)


### PR DESCRIPTION
Added a `startupPreparedHandler` to manage overview visibility during startup.

Fixes: #2492