### PR TITLE
Fix issue with original gnome-shell top menu having incorrect anchor points for newly-constructed menus

### DIFF
--- a/src/panelManager.js
+++ b/src/panelManager.js
@@ -291,7 +291,7 @@ export const PanelManager = class {
 
     Panel.panelBoxes.forEach((c) =>
       this._signalsHandler.add([
-        Main.panel[c],
+        this.primaryPanel[c],
         'child-added',
         (parent, child) => {
           this.primaryPanel &&


### PR DESCRIPTION
Closes #2479.

Menu items for the original shell menu were having their anchor points interfered with by the extension.

Before:

<img width="446" height="710" alt="Screenshot From 2026-05-31 02-50-17" src="https://github.com/user-attachments/assets/5c1b62ae-7a76-4fb5-bfc8-ef80bd1ccc04" />

After:

<img width="418" height="502" alt="Screenshot From 2026-05-31 12-04-39" src="https://github.com/user-attachments/assets/4e082db5-2294-4943-907f-3f7607957319" />
