### PR TITLE
Fix notification count badges for windowless (background) apps

### DIFF
--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -1614,8 +1614,6 @@ export const TaskbarAppIcon = GObject.registerClass(
     }
 
     _handleNotifications() {
-      if (!this._nWindows && !this.window) return
-
       let monitor = this.dtpPanel.panelManager.notificationsMonitor
       let state = monitor.getState(this.app)
       let count = 0


### PR DESCRIPTION
**Problem**
Apps that keep running in the background without windows (e.g. Geary with "Watch for new mail when closed", which runs as `geary --gapplication-service`) broadcast unread counts over the Unity LauncherEntry D-Bus API. Dash to Panel receives these updates but never draws a badge on the app's pinned icon: `_handleNotifications()` returns early when the app has no windows.

**Reproduction**
1. Pin an app that broadcasts LauncherEntry counts; let it run windowless (Geary's background service is a convenient case, or emit a synthetic `com.canonical.Unity.LauncherEntry.Update` signal for a pinned app's desktop id)
2. With a window open/minimized: badge appears ✔
3. With all windows closed (service still running, broadcasts still flowing): no badge ✘

**Fix**
Remove the windowless early-return. The `if (!state) return` immediately below already handles the no-data case, so icons without badge state cost nothing extra — the guard only discarded valid counts.

Related: #1695