### PR TITLE
Fix crash on disable when another extension's panel actors are already disposed

### DIFF
--- a/src/panelStyle.js
+++ b/src/panelStyle.js
@@ -278,6 +278,10 @@ export const PanelStyle = class {
   }
 
   _recursiveApply(actor, operations, restore) {
+    // actor may belong to another extension (e.g. appindicators) and already be
+    // disposed if that extension was disabled before us — skip it safely
+    if (!Utils.isValidActor(actor)) return
+
     for (let i in operations) {
       let o = operations[i]
       if (o.compareFn(actor))
@@ -326,6 +330,10 @@ export const PanelStyle = class {
     if (actor.visible) {
       //force gnome 3.34+ to refresh (having problem with the -natural-hpadding)
       let parent = actor.get_parent()
+
+      // actor may have been detached/disposed by its owning extension
+      if (!parent) return
+
       let children = parent.get_children()
       let actorIndex = 0
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -342,6 +342,22 @@ export const getTrackedActorData = (actor) => {
   if (trackedIndex >= 0) return Main.layoutManager._trackedActors[trackedIndex]
 }
 
+// Whether a Clutter actor's underlying GObject is still alive. Actors owned by
+// other extensions (e.g. ubuntu-appindicators) live in the shared panel and can
+// be finalized before dash-to-panel's own disable() runs — when extensions are
+// disabled in an order we don't control. Touching a finalized GObject throws
+// ("has been already disposed"); probing it here lets callers skip such actors.
+export const isValidActor = function (actor) {
+  if (!actor) return false
+
+  try {
+    // accessing any property on a finalized GObject throws
+    return actor.get_parent !== undefined
+  } catch {
+    return false
+  }
+}
+
 export const getTransformedAllocation = function (actor) {
   let extents = actor.get_transformed_extents()
   let topLeft = extents.get_top_left()


### PR DESCRIPTION
## Describe the bug

Dash-to-Panel crashes during `disable()` when **another** extension that owns
actors in the shared top panel has already been disabled (and its actors
finalized) before dash-to-panel's turn.

A reliable real-world trigger: the snap `firmware-updater` notifier runs on a
schedule and calls `gnome-extensions disable ubuntu-appindicators`. Its
`AppIndicatorsIconActor` objects are finalized, then dash-to-panel is disabled
and `PanelStyle._removeStyles()` recursively walks every panel child to restore
styles — touching those dead actors:

```
TypeError: this._indicator is null
  _waitForFullyReady@.../ubuntu-appindicators/appIndicator.js
  _refreshPanelButton@panelStyle.js
  _restoreOriginalStyle@panelStyle.js
  _recursiveApply@panelStyle.js
  _applyStylesRecursively@panelStyle.js
  _removeStyles@panelStyle.js
  disable@panelStyle.js
```

Accompanied by repeated:

```
Object .Gjs_ubuntu-appindicators..._AppIndicatorsIconActor, has been already
disposed — impossible to access it.
```

Accessing a finalized GObject throws, which spams the journal and aborts the
rest of the style-restore pass (panel left half-restored / flickering).

## Root cause

`_recursiveApply()` / `_refreshPanelButton()` assume every actor reachable from
the panel is still alive. We don't control the order in which extensions are
disabled, so actors owned by other extensions may already be finalized.

## Fix

- Add `Utils.isValidActor()` — probes whether an actor's underlying GObject is
  still alive (touching a finalized one throws).
- Skip dead actors at the top of `_recursiveApply()`.
- Add a null-parent guard in `_refreshPanelButton()` for actors detached by
  their owning extension.

No behaviour change for live actors; only already-disposed ones are skipped.

Related to #2439 (same class of disposed-actor crashes).

## Environment

- Ubuntu 24.04, GNOME Shell 46, Wayland
- Dash-to-Panel v73
