### PR TITLE
Implement "application-counter-overrides-notifications" setting

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1144,38 +1144,42 @@ msgid "Show notification counter badge"
 msgstr "Banner mit Anzahl der Benachrichtigungen anzeigen"
 
 #: ui/SettingsBehavior.ui.h:8
+msgid "Application counter overrides notification count"
+msgstr "Anwendungszähler überschreibt Benachrichtigungen"
+
+#: ui/SettingsBehavior.ui.h:9
 msgid "Hover"
 msgstr "Überfahren"
 
-#: ui/SettingsBehavior.ui.h:9
+#: ui/SettingsBehavior.ui.h:10
 msgid "Show window previews on hover"
 msgstr "Fenstervorschau bei Berührung einblenden"
 
-#: ui/SettingsBehavior.ui.h:10
+#: ui/SettingsBehavior.ui.h:11
 msgid "Show tooltip on hover"
 msgstr "Kurzinfo bei Berührung"
 
-#: ui/SettingsBehavior.ui.h:11
+#: ui/SettingsBehavior.ui.h:12
 msgid "Isolate"
 msgstr "Isolieren"
 
-#: ui/SettingsBehavior.ui.h:12
+#: ui/SettingsBehavior.ui.h:13
 msgid "Isolate Workspaces"
 msgstr "Arbeitsflächen isolieren"
 
-#: ui/SettingsBehavior.ui.h:13
+#: ui/SettingsBehavior.ui.h:14
 msgid "Isolate monitors"
 msgstr "Bildschirme isolieren"
 
-#: ui/SettingsBehavior.ui.h:14
+#: ui/SettingsBehavior.ui.h:15
 msgid "Overview"
 msgstr "Übersicht"
 
-#: ui/SettingsBehavior.ui.h:15
+#: ui/SettingsBehavior.ui.h:16
 msgid "Click empty space to close overview"
 msgstr "In leeren Bereich klicken, um Übersicht zu schließen"
 
-#: ui/SettingsBehavior.ui.h:16
+#: ui/SettingsBehavior.ui.h:17
 msgid "Disable show overview on startup"
 msgstr "Übersicht beim Start nicht anzeigen"
 

--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -1395,6 +1395,11 @@
       <summary>Show badge count on app icon</summary>
       <description>Whether to show badge count overlay on app icon, for supported applications.</description>
     </key>
+    <key type="b" name="application-counter-overrides-notifications">
+      <default>true</default>
+      <summary>Application counter overrides notifications</summary>
+      <description>Whether application-provided counters override notification counters.</description>
+    </key>
     <key type="s" name="target-prefs-page">
       <default>''</default>
       <summary>The preferences page name to display</summary>

--- a/src/notificationsMonitor.js
+++ b/src/notificationsMonitor.js
@@ -21,7 +21,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js'
 import * as MessageTray from 'resource:///org/gnome/shell/ui/messageTray.js'
 import { EventEmitter } from 'resource:///org/gnome/shell/misc/signals.js'
 
-import { tracker } from './extension.js'
+import { SETTINGS, tracker } from './extension.js'
 import * as Utils from './utils.js'
 
 const knownIdMappings = {
@@ -63,6 +63,11 @@ export const NotificationsMonitor = class extends EventEmitter {
         if (tracker.focus_app && this._state[appId])
           this._updateState(tracker.focus_app.id, this._getDefaultState(), true)
       },
+    ])
+    this._signalsHandler.add([
+      SETTINGS,
+      'changed::application-counter-overrides-notifications',
+      () => this._refreshState(),
     ])
     this._acquireUnityDBus()
 
@@ -110,6 +115,12 @@ export const NotificationsMonitor = class extends EventEmitter {
     return this._state[app.id]
   }
 
+  _refreshState() {
+    Object.keys(this._state).forEach((appId) => {
+      if (this._mergeState(appId, {})) this.emit(`update-${appId}`)
+    })
+  }
+
   _mergeState(appId, state) {
     let currenState = JSON.stringify(this._state[appId])
 
@@ -125,9 +136,18 @@ export const NotificationsMonitor = class extends EventEmitter {
       (this._state[appId].trayUrgent && this._state[appId].trayCount) ||
       false
 
-    this._state[appId].total =
-      ((this._state[appId]['count-visible'] || 0) &&
-        (this._state[appId].count || 0)) + (this._state[appId].trayCount || 0)
+    // If the app sets a counter-badge already, just trust it by default,
+    // but fall back to the notification count.
+    // application-counter-overrides-notifications can be used to count both.
+    const appProvided =
+      (this._state[appId]['count-visible'] || 0) &&
+      (this._state[appId].count || 0)
+    const trayCount = this._state[appId].trayCount || 0
+    this._state[appId].total = SETTINGS.get_boolean(
+      'application-counter-overrides-notifications',
+    )
+      ? appProvided || trayCount
+      : appProvided + trayCount
 
     return currenState != JSON.stringify(this._state[appId])
   }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -2675,6 +2675,24 @@ const Preferences = class {
       Gio.SettingsBindFlags.DEFAULT,
     )
 
+    this._settings.bind(
+      'application-counter-overrides-notifications',
+      this._builder.get_object(
+        'application_counter_overrides_notifications_switch',
+      ),
+      'active',
+      Gio.SettingsBindFlags.DEFAULT,
+    )
+
+    this._settings.bind(
+      'progress-show-count',
+      this._builder.get_object(
+        'application_counter_overrides_notifications_switch',
+      ),
+      'sensitive',
+      Gio.SettingsBindFlags.DEFAULT,
+    )
+
     this._builder
       .get_object('group_apps_label_font_color_colorbutton')
       .connect('color-set', (button) => {

--- a/ui/SettingsBehavior.ui
+++ b/ui/SettingsBehavior.ui
@@ -74,6 +74,18 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Application counter overrides notifications</property>
+            <child>
+              <object class="GtkSwitch" id="application_counter_overrides_notifications_switch">
+                <property name="halign">end</property>
+                <property name="valign">center</property>
+                <property name="visible">True</property>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child>


### PR DESCRIPTION
Fixes #2515 by not summing up notification count and app provided count (`com.canonical.Unity.LauncherEntry`) by default.

A setting is provided to restore the original behavior. I have made the new behavior the default, because I do not think the old behavior (before this PR) is useful, it will usually just result in a badge counter that is twice as high as it should be.

I have added German localization for the new setting, as that is the only language besides English that I speak.

This is my first time working on _anything_ related to GNOME extensions, please let me know if I have done something wrong. I have tested this locally with `make install` and it worked fine.