### PR TITLE
Fixed mid-animation crash for peeks

### DIFF
--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -1590,7 +1590,7 @@ export const TaskbarItemContainer = GObject.registerClass(
     // restore opacity before dashItemContainer.animateOutAndDestroy does the destroy animation.
     animateOutAndDestroy() {
       if (this._raisedClone) {
-        this._raisedClone.source.opacity = 255
+        this._raisedClone.source?.set_opacity(255)
         this._raisedClone.destroy()
       }
 
@@ -1740,7 +1740,7 @@ export const TaskbarItemContainer = GObject.registerClass(
         transition: 'easeOutQuad',
         onComplete: () => {
           if (!level) {
-            this._raisedClone.source.opacity = 255
+            this._raisedClone.source?.set_opacity(255)
             this._raisedClone.destroy()
             delete this._raisedClone
           }


### PR DESCRIPTION
While trying to fix a bug I had, I discovered another. Figured I'd fix it first before I moved onto mine. (Unfortunately mine requires design decisions that I don't think is my place to do - probably a new Set or such.)

One thing; I know you use `foo = bar` more style wise. But I felt this was cleaner over an if block. Can rewrite it to an if block if thatsa preference.

Noticed #1712 is still occurring. So this will fix that. Lint, etc pass.