### PR TITLE
feat: custom app icon size

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -838,6 +838,11 @@
         <summary>App icon padding</summary>
         <description>Set the padding for application icons in the embedded dash.</description>
     </key>
+    <key type="i" name="appicon-size">
+        <default>0</default>
+        <summary>App icon size</summary>
+        <description>Set the size of application icons. (0 = auto)</description>
+    </key>
     <key type="i" name="tray-padding">
         <default>-1</default>
         <summary>Tray item padding</summary>

--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -857,13 +857,22 @@ export const TaskbarAppIcon = GObject.registerClass(
 
     _setAppIconPadding() {
       const padding = getIconPadding(this.dtpPanel)
+      const crossPadding = getIconCrossPadding(this.dtpPanel)
       const margin = SETTINGS.get_int('appicon-margin')
       let vertical = this.dtpPanel.geom.vertical
 
       this.set_style(
         `padding: ${vertical ? margin : 0}px ${vertical ? 0 : margin}px;`,
       )
-      this._iconContainer.set_style('padding: ' + padding + 'px;')
+
+      // If a smaller icon size is set, the container will shrink to the icon,
+      // so we need to add padding on the cross axis to compensate or else the
+      // other elements will be misaligned.
+      this._iconContainer.set_style(
+        vertical
+          ? `padding: ${padding}px ${crossPadding}px;`
+          : `padding: ${crossPadding}px ${padding}px;`,
+      )
     }
 
     _setAppIconStyle() {
@@ -1902,6 +1911,24 @@ export function getIconPadding(dtpPanel) {
   return padding
 }
 
+export function getIconCrossPadding(dtpPanel) {
+  let padding = getIconPadding(dtpPanel)
+  let customIconSize = SETTINGS.get_int('appicon-size')
+
+  if (customIconSize <= 0) {
+    return padding
+  }
+
+  let panelSize = dtpPanel.geom.iconSize / Utils.getScaleFactor()
+  let availSize = panelSize - SETTINGS.get_int('appicon-padding') * 2
+
+  if (customIconSize >= availSize) {
+    return padding
+  }
+
+  return (panelSize - customIconSize) * 0.5
+}
+
 /**
  * Extend AppMenu (AppIconMenu for pre gnome 41)
  *
@@ -2137,6 +2164,11 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
       'changed::appicon-padding',
       () => this.setShowAppsPadding(),
     )
+
+    this._changedAppIconSizeId = SETTINGS.connect('changed::appicon-size', () =>
+      this.setShowAppsPadding(),
+    )
+
     this._changedAppIconSidePaddingId = SETTINGS.connect(
       'changed::show-apps-icon-side-padding',
       () => this.setShowAppsPadding(),
@@ -2175,14 +2207,15 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
 
   setShowAppsPadding() {
     let padding = getIconPadding(this.realShowAppsIcon._dtpPanel)
+    let crossPadding = getIconCrossPadding(this.realShowAppsIcon._dtpPanel)
     let sidePadding = SETTINGS.get_int('show-apps-icon-side-padding')
     let isVertical = this.realShowAppsIcon._dtpPanel.geom.vertical
 
     this.actor.set_style(
       'padding:' +
-        (padding + (isVertical ? sidePadding : 0)) +
+        (isVertical ? padding + sidePadding : crossPadding) +
         'px ' +
-        (padding + (isVertical ? 0 : sidePadding)) +
+        (isVertical ? crossPadding : padding + sidePadding) +
         'px;',
     )
   }
@@ -2239,6 +2272,7 @@ export const ShowAppsIconWrapper = class extends EventEmitter {
     SETTINGS.disconnect(this._changedShowAppsIconId)
     SETTINGS.disconnect(this._changedAppIconSidePaddingId)
     SETTINGS.disconnect(this._changedAppIconPaddingId)
+    SETTINGS.disconnect(this._changedAppIconSizeId)
 
     this.realShowAppsIcon.destroy()
   }

--- a/src/panel.js
+++ b/src/panel.js
@@ -653,7 +653,11 @@ export const Panel = GObject.registerClass(
         ],
         [
           SETTINGS,
-          ['changed::appicon-margin', 'changed::appicon-padding'],
+          [
+            'changed::appicon-margin',
+            'changed::appicon-padding',
+            'changed::appicon-size',
+          ],
           () => this.taskbar.resetAppIcons(),
         ],
         [

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -40,6 +40,7 @@ import {
 
 const SCALE_UPDATE_TIMEOUT = 500
 const DEFAULT_PANEL_SIZES = [128, 96, 64, 48, 32, 22]
+const DEFAULT_ICON_SIZES = [128, 96, 64, 48, 32, 24, 16, 0]
 const DEFAULT_FONT_SIZES = [96, 64, 48, 32, 24, 16, 0]
 const DEFAULT_MARGIN_SIZES = [32, 24, 16, 12, 8, 4, 0]
 const DEFAULT_PADDING_SIZES = [32, 24, 16, 12, 8, 4, 0, -1]
@@ -3393,6 +3394,11 @@ const Preferences = class {
         range: DEFAULT_MARGIN_SIZES,
       },
       {
+        objectName: 'appicon_size_scale',
+        valueName: 'appicon-size',
+        range: DEFAULT_ICON_SIZES,
+      },
+      {
         objectName: 'tray_padding_scale',
         valueName: 'tray-padding',
         range: DEFAULT_PADDING_SIZES,
@@ -3483,6 +3489,12 @@ const Preferences = class {
     )
 
     // animate hovering app icons dialog
+    this._builder
+      .get_object('appicon_size_scale')
+      .set_format_value_func((scale, value) => {
+        return value === 0 ? _('auto') : `${value} px`
+      })
+
     this._builder
       .get_object('animate_appicon_hover_options_duration_scale')
       .set_format_value_func((scale, value) => {

--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -951,6 +951,11 @@ export const Taskbar = class extends EventEmitter {
     let panelSize = this.dtpPanel.geom.iconSize / Utils.getScaleFactor()
     let availSize = panelSize - SETTINGS.get_int('appicon-padding') * 2
     let minIconSize = MIN_ICON_SIZE + (panelSize % 2)
+    let customIconSize = SETTINGS.get_int('appicon-size')
+
+    if (customIconSize > 0 && customIconSize < availSize) {
+      availSize = customIconSize
+    }
 
     if (availSize == this.iconSize) return
 

--- a/ui/SettingsStyle.ui
+++ b/ui/SettingsStyle.ui
@@ -15,6 +15,12 @@
     <property name="step-increment">0.01</property>
     <property name="upper">1</property>
   </object>
+  <object class="GtkAdjustment" id="appicon_size_adjustment">
+    <property name="lower">0.33</property>
+    <property name="page-increment">0.1</property>
+    <property name="step-increment">0.01</property>
+    <property name="upper">1</property>
+  </object>
   <object class="GtkAdjustment" id="panel_side_margins_adjustment">
     <property name="lower">0.33</property>
     <property name="page-increment">0.1</property>
@@ -117,6 +123,22 @@
             <child>
               <object class="GtkScale" id="appicon_padding_scale">
                 <property name="adjustment">appicon_padding_adjustment</property>
+                <property name="digits">0</property>
+                <property name="draw-value">True</property>
+                <property name="round-digits">0</property>
+                <property name="value-pos">right</property>
+                <property name="width-request">300</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwActionRow">
+            <property name="subtitle" translatable="yes">(0 = auto)</property>
+            <property name="title" translatable="yes">App Icon Size</property>
+            <child>
+              <object class="GtkScale" id="appicon_size_scale">
+                <property name="adjustment">appicon_size_adjustment</property>
                 <property name="digits">0</property>
                 <property name="draw-value">True</property>
                 <property name="round-digits">0</property>


### PR DESCRIPTION
Resolves #2240

Add a way to set the icon size specifically in the extension settings.

Without this, the only way to reduce the icon size relative to the panel, is by setting the padding. However, this is a crude tool for the job and doesn't quite achieve the intended effect; you end up having to accept additional space to the sides (or, if vertical, tops and bottoms) of the icon. So there really isn't a true way to _just_ reduce the size of the icon relative to the panel thickness, without affecting the rest of the layout.

With this change, one can now set a custom icon size. If the size is smaller than the panel thickness, it takes effect; otherwise, it clamps to the max size it would have been after padding, as it behaves currently.