### PR TITLE
fix: orphaned raised clone and shared hover timeout on disposed actors

### DIFF
--- a/WEBDEVBAR-NOTES.md
+++ b/WEBDEVBAR-NOTES.md
@@ -1,0 +1,113 @@
+# WebDevBar fork notes — dash-to-panel
+
+Why this fork exists, what it carries, and what is planned. Not upstream documentation.
+Started 2026-07-30 on Fedora 44 / GNOME Shell 50.0 (Wayland).
+
+## What this fork carries
+
+`master` is upstream `master` plus:
+
+| Commits | What | Upstream status |
+|---|---|---|
+| `c3941a9`…`03ade4a` (6) | PR **#2493** — `startupPreparedHandler` for overview control on GNOME 50, cherry-picked with authorship preserved | **open** |
+| `41c4b87` | Our own: avoid a redundant `hasOverview` set-and-revert in the already-started branch | not submitted |
+| `b1db153` (merge `4b1548f`) | PR **#2509** — our `+0/-2`, badges for windowless apps | **open** since 2026-06-02 |
+
+Build and install with `make install-local` (→ `~/.local/share/gnome-shell/extensions/`, which wins
+over the Fedora RPM's `/usr/share`). **Do not install the Fedora RPM alongside** — same UUID.
+GNOME caches extension JS, so a code change needs a full relogin on Wayland, not just
+disable/enable.
+
+### #2493 — verified working, with a known ceiling
+
+Tested by relogin on GNOME 50: no overview at login, but **the overview *background* is briefly
+visible and then animates away.** That is not a shortfall of this PR. Three independent
+implementations behave identically — #2493, our own earlier local patch, and Simple Taskbar's
+`overviewIntegration.js` — because by the time any extension's `enable()` runs, the shell's startup
+animation is already going and there is no API to stop it (the PR's own comment says so). Treated as
+a ceiling; masked instead by the **Overview Background** extension (EGO 5856) with blur 0, which
+makes the flash read as the desktop wallpaper.
+
+Reviewed while cherry-picking: DtP **already** restores `hasOverview` on disable
+(`src/extension.js:185`), so an earlier assumption that Simple Taskbar was more careful there was
+wrong.
+
+## 🔲 PLANNED — `notification-clear-on-focus` (not started, do not implement yet)
+
+**Observed behaviour (2026-07-30).** DtP clears a notification count as soon as the app is focused:
+
+- `src/notificationsMonitor.js` `_mergeState()` — `if (tracker.focus_app?.id == appId)` zeroes both
+  `count` (Unity/LauncherEntry) and `trayCount` (MessageTray).
+- the `notify::focus-app` handler (~lines 56-66) additionally resets the whole state to default.
+
+Consequence, as seen in practice with Mailspring and with Brave: the badge shows unread, you open
+the app once, the count zeroes, and from then on **only new arrivals** can produce a badge — the
+pre-existing unread total never comes back.
+
+**This is a defensible default** ("you have seen it"), and it is *not* a bug. So the proposal is an
+**opt-in setting, not a behaviour change**:
+
+| | |
+|---|---|
+| Key | `notification-clear-on-focus`, boolean, **default `true`** |
+| `true` | exactly today's behaviour — nothing changes for any existing user |
+| `false` | do not zero on focus; the badge keeps the emitter's count and falls as messages are read |
+| Touch points | a key in `schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml`, a checkbox in `prefs.js`, and two guards in `notificationsMonitor.js` (`_mergeState` + the `notify::focus-app` handler) |
+
+**Gate only `count`, never `trayCount`** — and say why in the PR, because a reviewer will ask:
+
+- The Unity `count` is **authoritative and self-correcting**. Measured on the session bus: Mailspring
+  emits `application://Mailspring.desktop` with `count` **descending 20 → 19 → 18** as messages are
+  read, `count-visible: true`, roughly once per second. So persisting it is safe — the app itself
+  drives it back to zero.
+- `trayCount` comes from MessageTray banners with **no decrement signal**. Persisting it would
+  produce a badge that can never clear, which is a worse bug than the one being fixed.
+
+## Verified facts about the badge path (measured, not inferred)
+
+Useful when writing either PR comment.
+
+- **The emitter's id must match the desktop-file id exactly, case included.**
+  `_handleLauncherUpdate()` strips the scheme from `application://Mailspring.desktop`;
+  `_updateState()` strips `.desktop`, consults `knownIdMappings` (which has exactly ONE entry, for
+  Evolution), re-appends `.desktop`, and emits `` `update-${appId}` ``; icons subscribe to
+  `` `update-${this.app.id}` `` (`src/appIcons.js:305-307`). No normalisation anywhere.
+- **Two defects in that same function**, both worth a separate hardening PR:
+  1. matching is case-sensitive, so an emitter whose casing differs from the installed `.desktop`
+     name writes state under a key no icon listens to;
+  2. `appId.replace('.desktop', '')` is **unanchored** — it strips the first occurrence anywhere
+     rather than the suffix. Should be `/\.desktop$/`.
+  Note `Shell.AppSystem.lookup_app()` is itself exact-match, so the fix is: exact lookup first, then
+  a **cached** case-insensitive scan of installed ids, invalidated on `installed-changed`. Keep
+  `knownIdMappings` — it solves a different problem (daemon ids).
+- **`count-visible` handling is correct**, despite looking wrong. `notificationsMonitor.js:128-130`
+  does `((state['count-visible'] || 0) && (state.count || 0)) + (state.trayCount || 0)`; the boolean
+  collapses to `0` on the falsy paths before the addition. Do **not** raise this upstream — two
+  independent reviews confirmed it is spec-compliant, and claiming it as a bug would be refutable.
+- **`LauncherEntry` is not vestigial.** The `// pretty much useless` comment above the subscription
+  is wrong: that subscription is the only code path populating `count`, `count-visible` and the Unity
+  half of `urgent`. `_checkNotifications()` writes only `trayCount`/`trayUrgent`, from banners that
+  reset on focus. For any app publishing unread state via LauncherEntry, that subscription **is** the
+  badge feature.
+- **The guard #2509 removes also caused stale badges** — the early return skipped
+  `_maybeUpdateNumberOverlay()`, so a badge already drawn could neither update nor clear once the
+  last window closed.
+- **Wording**: "windowless apps" is imprecise. `src/taskbar.js` (~1028-1031) keeps a zero-window icon
+  only if the app is a favourite, so the accurate description is **"pinned apps backed by a
+  background service"**.
+
+## Mailspring-specific gotchas found while testing (not DtP bugs)
+
+- **The app must actually be running.** Quitting Mailspring takes the emitter with it, so no badge is
+  correct. It needs to sit in the tray — `~/.config/autostart/Mailspring.desktop` with
+  `Exec=/usr/bin/mailspring --background`, plus Mailspring's own keep-running preference.
+- **`Mailspring.desktop` needs a capital M** — the emitter hardcodes
+  `application://Mailspring.desktop`. The official 1.23.0 RPM ships it correctly.
+- **The RPM's launcher has no `StartupWMClass`.** GNOME's `WindowTracker` matches a window by
+  lowercasing `WM_CLASS` and looking for `<wmclass>.desktop`, i.e. `mailspring.desktop`, which does
+  not exist on a case-sensitive filesystem. Added `StartupWMClass=Mailspring` to the user-level
+  launcher. **Possibly worth reporting to Mailspring** — without it GNOME cannot reliably match its
+  own window, independent of which taskbar extension is used.
+- **Mailspring has no GNOME Online Accounts integration** — zero references to `goa-1.0`,
+  `org.gnome.OnlineAccounts` or `GoaClient` in `app.asar`. It ships its own OAuth client and IMAP
+  engine, so accounts are authorised separately from GOA. Not a missing setting.

--- a/WEBDEVBAR-NOTES.md
+++ b/WEBDEVBAR-NOTES.md
@@ -63,6 +63,32 @@ pre-existing unread total never comes back.
 - `trayCount` comes from MessageTray banners with **no decrement signal**. Persisting it would
   produce a badge that can never clear, which is a worse bug than the one being fixed.
 
+## ⚠ THE TRAP THAT COST AN AFTERNOON — GNOME caches extension modules
+
+**`grep` on the installed file proves NOTHING about what the shell is running.** GNOME imports
+extension ES modules once per shell process; `disable`/`enable` does **not** reload changed code —
+only a full shell restart (logout/login on Wayland) does.
+
+On 2026-07-30 this produced a completely false conclusion. The badge fix was installed at 14:10, the
+shell had been running since 13:31, and the windowless badge therefore still failed. A `grep -c` on
+the installed `appIcons.js` returned 0 occurrences of the guard, which "confirmed" the fix was
+active — so the failure looked like proof that PR #2509 does not work on GNOME 50. Two independent
+code reviews then reasoned correctly about a checkout that **was not the running code**.
+
+After a verified relogin (`ps -o lstart -C gnome-shell` postdating the install), the identical test
+passed: **the windowless badge appears, and #2509 works.**
+
+**Before concluding any patch does not work:**
+
+```bash
+ps -o lstart= -C gnome-shell          # when did the running shell start?
+stat -c '%y' ~/.local/share/gnome-shell/extensions/<uuid>/<file>.js
+journalctl --user -b | grep -i "GNOME Shell started" | tail -1
+```
+
+If the shell predates the file, you are testing old code. This belongs in the "verify, don't assume"
+column: a file on disk is not a loaded module, and a passing `grep` is not a passing test.
+
 ## Verified facts about the badge path (measured, not inferred)
 
 Useful when writing either PR comment.

--- a/WEBDEVBAR-NOTES.md
+++ b/WEBDEVBAR-NOTES.md
@@ -1,4 +1,4 @@
-# WebDevBar fork notes — dash-to-panel
+# WebDevBar fork notes - dash-to-panel
 
 Why this fork exists, what it carries, and what is planned. Not upstream documentation.
 Started 2026-07-30 on Fedora 44 / GNOME Shell 50.0 (Wayland).
@@ -9,21 +9,21 @@ Started 2026-07-30 on Fedora 44 / GNOME Shell 50.0 (Wayland).
 
 | Commits | What | Upstream status |
 |---|---|---|
-| `c3941a9`…`03ade4a` (6) | PR **#2493** — `startupPreparedHandler` for overview control on GNOME 50, cherry-picked with authorship preserved | **open** |
+| `c3941a9`…`03ade4a` (6) | PR **#2493** - `startupPreparedHandler` for overview control on GNOME 50, cherry-picked with authorship preserved | **open** |
 | `41c4b87` | Our own: avoid a redundant `hasOverview` set-and-revert in the already-started branch | not submitted |
-| `b1db153` (merge `4b1548f`) | PR **#2509** — our `+0/-2`, badges for windowless apps | **open** since 2026-06-02 |
+| `b1db153` (merge `4b1548f`) | PR **#2509** - our `+0/-2`, badges for windowless apps | **open** since 2026-06-02 |
 
 Build and install with `make install-local` (→ `~/.local/share/gnome-shell/extensions/`, which wins
-over the Fedora RPM's `/usr/share`). **Do not install the Fedora RPM alongside** — same UUID.
+over the Fedora RPM's `/usr/share`). **Do not install the Fedora RPM alongside** - same UUID.
 GNOME caches extension JS, so a code change needs a full relogin on Wayland, not just
 disable/enable.
 
-### #2493 — verified working, with a known ceiling
+### #2493 - verified working, with a known ceiling
 
 Tested by relogin on GNOME 50: no overview at login, but **the overview *background* is briefly
 visible and then animates away.** That is not a shortfall of this PR. Three independent
-implementations behave identically — #2493, our own earlier local patch, and Simple Taskbar's
-`overviewIntegration.js` — because by the time any extension's `enable()` runs, the shell's startup
+implementations behave identically - #2493, our own earlier local patch, and Simple Taskbar's
+`overviewIntegration.js` - because by the time any extension's `enable()` runs, the shell's startup
 animation is already going and there is no API to stop it (the PR's own comment says so). Treated as
 a ceiling; masked instead by the **Overview Background** extension (EGO 5856) with blur 0, which
 makes the flash read as the desktop wallpaper.
@@ -32,16 +32,16 @@ Reviewed while cherry-picking: DtP **already** restores `hasOverview` on disable
 (`src/extension.js:185`), so an earlier assumption that Simple Taskbar was more careful there was
 wrong.
 
-## 🔲 PLANNED — `notification-clear-on-focus` (not started, do not implement yet)
+## 🔲 PLANNED - `notification-clear-on-focus` (not started, do not implement yet)
 
 **Observed behaviour (2026-07-30).** DtP clears a notification count as soon as the app is focused:
 
-- `src/notificationsMonitor.js` `_mergeState()` — `if (tracker.focus_app?.id == appId)` zeroes both
+- `src/notificationsMonitor.js` `_mergeState()` - `if (tracker.focus_app?.id == appId)` zeroes both
   `count` (Unity/LauncherEntry) and `trayCount` (MessageTray).
 - the `notify::focus-app` handler (~lines 56-66) additionally resets the whole state to default.
 
 Consequence, as seen in practice with Mailspring and with Brave: the badge shows unread, you open
-the app once, the count zeroes, and from then on **only new arrivals** can produce a badge — the
+the app once, the count zeroes, and from then on **only new arrivals** can produce a badge - the
 pre-existing unread total never comes back.
 
 **This is a defensible default** ("you have seen it"), and it is *not* a bug. So the proposal is an
@@ -50,29 +50,29 @@ pre-existing unread total never comes back.
 | | |
 |---|---|
 | Key | `notification-clear-on-focus`, boolean, **default `true`** |
-| `true` | exactly today's behaviour — nothing changes for any existing user |
+| `true` | exactly today's behaviour - nothing changes for any existing user |
 | `false` | do not zero on focus; the badge keeps the emitter's count and falls as messages are read |
 | Touch points | a key in `schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml`, a checkbox in `prefs.js`, and two guards in `notificationsMonitor.js` (`_mergeState` + the `notify::focus-app` handler) |
 
-**Gate only `count`, never `trayCount`** — and say why in the PR, because a reviewer will ask:
+**Gate only `count`, never `trayCount`** - and say why in the PR, because a reviewer will ask:
 
 - The Unity `count` is **authoritative and self-correcting**. Measured on the session bus: Mailspring
   emits `application://Mailspring.desktop` with `count` **descending 20 → 19 → 18** as messages are
-  read, `count-visible: true`, roughly once per second. So persisting it is safe — the app itself
+  read, `count-visible: true`, roughly once per second. So persisting it is safe - the app itself
   drives it back to zero.
 - `trayCount` comes from MessageTray banners with **no decrement signal**. Persisting it would
   produce a badge that can never clear, which is a worse bug than the one being fixed.
 
-## ⚠ THE TRAP THAT COST AN AFTERNOON — GNOME caches extension modules
+## ⚠ THE TRAP THAT COST AN AFTERNOON - GNOME caches extension modules
 
 **`grep` on the installed file proves NOTHING about what the shell is running.** GNOME imports
-extension ES modules once per shell process; `disable`/`enable` does **not** reload changed code —
+extension ES modules once per shell process; `disable`/`enable` does **not** reload changed code  - 
 only a full shell restart (logout/login on Wayland) does.
 
 On 2026-07-30 this produced a completely false conclusion. The badge fix was installed at 14:10, the
 shell had been running since 13:31, and the windowless badge therefore still failed. A `grep -c` on
 the installed `appIcons.js` returned 0 occurrences of the guard, which "confirmed" the fix was
-active — so the failure looked like proof that PR #2509 does not work on GNOME 50. Two independent
+active - so the failure looked like proof that PR #2509 does not work on GNOME 50. Two independent
 code reviews then reasoned correctly about a checkout that **was not the running code**.
 
 After a verified relogin (`ps -o lstart -C gnome-shell` postdating the install), the identical test
@@ -101,21 +101,21 @@ Useful when writing either PR comment.
 - **Two defects in that same function**, both worth a separate hardening PR:
   1. matching is case-sensitive, so an emitter whose casing differs from the installed `.desktop`
      name writes state under a key no icon listens to;
-  2. `appId.replace('.desktop', '')` is **unanchored** — it strips the first occurrence anywhere
+  2. `appId.replace('.desktop', '')` is **unanchored** - it strips the first occurrence anywhere
      rather than the suffix. Should be `/\.desktop$/`.
   Note `Shell.AppSystem.lookup_app()` is itself exact-match, so the fix is: exact lookup first, then
   a **cached** case-insensitive scan of installed ids, invalidated on `installed-changed`. Keep
-  `knownIdMappings` — it solves a different problem (daemon ids).
+  `knownIdMappings` - it solves a different problem (daemon ids).
 - **`count-visible` handling is correct**, despite looking wrong. `notificationsMonitor.js:128-130`
   does `((state['count-visible'] || 0) && (state.count || 0)) + (state.trayCount || 0)`; the boolean
-  collapses to `0` on the falsy paths before the addition. Do **not** raise this upstream — two
+  collapses to `0` on the falsy paths before the addition. Do **not** raise this upstream - two
   independent reviews confirmed it is spec-compliant, and claiming it as a bug would be refutable.
 - **`LauncherEntry` is not vestigial.** The `// pretty much useless` comment above the subscription
   is wrong: that subscription is the only code path populating `count`, `count-visible` and the Unity
   half of `urgent`. `_checkNotifications()` writes only `trayCount`/`trayUrgent`, from banners that
   reset on focus. For any app publishing unread state via LauncherEntry, that subscription **is** the
   badge feature.
-- **The guard #2509 removes also caused stale badges** — the early return skipped
+- **The guard #2509 removes also caused stale badges** - the early return skipped
   `_maybeUpdateNumberOverlay()`, so a badge already drawn could neither update nor clear once the
   last window closed.
 - **Wording**: "windowless apps" is imprecise. `src/taskbar.js` (~1028-1031) keeps a zero-window icon
@@ -125,15 +125,15 @@ Useful when writing either PR comment.
 ## Mailspring-specific gotchas found while testing (not DtP bugs)
 
 - **The app must actually be running.** Quitting Mailspring takes the emitter with it, so no badge is
-  correct. It needs to sit in the tray — `~/.config/autostart/Mailspring.desktop` with
+  correct. It needs to sit in the tray - `~/.config/autostart/Mailspring.desktop` with
   `Exec=/usr/bin/mailspring --background`, plus Mailspring's own keep-running preference.
-- **`Mailspring.desktop` needs a capital M** — the emitter hardcodes
+- **`Mailspring.desktop` needs a capital M** - the emitter hardcodes
   `application://Mailspring.desktop`. The official 1.23.0 RPM ships it correctly.
 - **The RPM's launcher has no `StartupWMClass`.** GNOME's `WindowTracker` matches a window by
   lowercasing `WM_CLASS` and looking for `<wmclass>.desktop`, i.e. `mailspring.desktop`, which does
   not exist on a case-sensitive filesystem. Added `StartupWMClass=Mailspring` to the user-level
-  launcher. **Possibly worth reporting to Mailspring** — without it GNOME cannot reliably match its
+  launcher. **Possibly worth reporting to Mailspring** - without it GNOME cannot reliably match its
   own window, independent of which taskbar extension is used.
-- **Mailspring has no GNOME Online Accounts integration** — zero references to `goa-1.0`,
+- **Mailspring has no GNOME Online Accounts integration** - zero references to `goa-1.0`,
   `org.gnome.OnlineAccounts` or `GoaClient` in `app.asar`. It ships its own OAuth client and IMAP
   engine, so accounts are authorised separately from GOA. Not a missing setting.

--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -1614,8 +1614,6 @@ export const TaskbarAppIcon = GObject.registerClass(
     }
 
     _handleNotifications() {
-      if (!this._nWindows && !this.window) return
-
       let monitor = this.dtpPanel.panelManager.notificationsMonitor
       let state = monitor.getState(this.app)
       let count = 0

--- a/src/extension.js
+++ b/src/extension.js
@@ -113,8 +113,6 @@ export default class DashToPanelExtension extends Extension {
     )
 
     if (SETTINGS.get_boolean('hide-overview-on-startup')) {
-      Main.sessionMode.hasOverview = false
-
       // GNOME 50 changed extension load timing - on at least some
       // hardware, dash-to-panel's enable() runs after the shell startup
       // animation has fully completed (Main.layoutManager._startingUp
@@ -123,6 +121,8 @@ export default class DashToPanelExtension extends Extension {
       // nothing in that case. Drop the gate and act on actual state:
       // if the overview is showing when we load, hide it.
       if (Main.layoutManager._startingUp) {
+        Main.sessionMode.hasOverview = false
+
         // Still in startup - hide on completion as before. The shell's
         // _startupAnimationComplete fires startup-complete after the
         // cover pane is destroyed, so a normal hide() runs cleanly.
@@ -134,9 +134,9 @@ export default class DashToPanelExtension extends Extension {
           },
         )
       } else {
-        // Startup is already done. Restore hasOverview and hide if
-        // currently shown.
-        Main.sessionMode.hasOverview = this._realHasOverview
+        // Startup is already done, so there is nothing to suppress and
+        // hasOverview was never changed - just hide the overview if the
+        // shell brought us up with it already showing.
         if (Main.overview.visible || Main.overview._shown) {
           Main.overview.hide()
         }

--- a/src/extension.js
+++ b/src/extension.js
@@ -38,7 +38,7 @@ const UBUNTU_DOCK_UUID = 'ubuntu-dock@ubuntu.com'
 
 let panelManager
 let startupCompleteHandler
-let startupPreparedHandler
+let originalPrepareStartupAnimation
 let ubuntuDockDelayId = 0
 
 export let DTP_EXTENSION = null
@@ -121,32 +121,31 @@ export default class DashToPanelExtension extends Extension {
 
       // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral in
       // Layout._loadBackground that previously held _prepareStartupAnimation
-      // until after the extension-enable chain had run. Without it, the
-      // startup-animation chain and the extension-enable chain are
-      // independent promise chains with no guaranteed ordering.
+      // until the extension-enable chain had run. _doStartupAnimation now
+      // reads Main.sessionMode.hasOverview at two awaits with no ordering
+      // guarantee against extension init - first in _prepareStartupAnimation
+      // (decides uiGroup pre-scale), then in _startupAnimationSession
+      // (decides the animation branch).
       //
-      // _doStartupAnimation reads Main.sessionMode.hasOverview twice:
-      //   1. layout.js _prepareStartupAnimation (decides whether to
-      //      pre-scale uiGroup for the grow-out animation)
-      //   2. layout.js _startupAnimationSession (decides whether to call
-      //      Main.overview.runStartupAnimation)
-      //
-      // 'startup-prepared' fires synchronously between those two reads.
-      // The synchronous assignment above often wins both races on faster
-      // hardware, but on slower setups it can lose the first one. The
-      // handler below is a second line of defense for the second read.
-      //
-      // Defensive: disconnect any previous handler before reconnecting,
-      // in case enable() runs again before startup-complete fired.
-      if (startupPreparedHandler) {
-        Main.layoutManager.disconnect(startupPreparedHandler)
-      }
-      startupPreparedHandler = Main.layoutManager.connect(
-        'startup-prepared',
-        () => {
+      // Wrapping _prepareStartupAnimation lets us re-assert hasOverview
+      // synchronously, before either read happens. The wrapper restores
+      // itself on first call so we don't keep monkey-patching shell
+      // internals longer than necessary.
+      if (
+        Config.PACKAGE_VERSION >= '50' &&
+        !originalPrepareStartupAnimation &&
+        typeof Main.layoutManager._prepareStartupAnimation === 'function'
+      ) {
+        originalPrepareStartupAnimation =
+          Main.layoutManager._prepareStartupAnimation
+        Main.layoutManager._prepareStartupAnimation = function (...args) {
           Main.sessionMode.hasOverview = false
-        },
-      )
+          Main.layoutManager._prepareStartupAnimation =
+            originalPrepareStartupAnimation
+          originalPrepareStartupAnimation = null
+          return Main.layoutManager._prepareStartupAnimation.apply(this, args)
+        }
+      }
 
       startupCompleteHandler = Main.layoutManager.connect(
         'startup-complete',
@@ -203,9 +202,12 @@ export default class DashToPanelExtension extends Extension {
 
     AppIcons.resetRecentlyClickedApp()
 
-    if (startupPreparedHandler) {
-      Main.layoutManager.disconnect(startupPreparedHandler)
-      startupPreparedHandler = null
+    // Restore the wrapper if _prepareStartupAnimation never ran (i.e.
+    // extension disabled before login finished, unusual but possible).
+    if (originalPrepareStartupAnimation) {
+      Main.layoutManager._prepareStartupAnimation =
+        originalPrepareStartupAnimation
+      originalPrepareStartupAnimation = null
     }
 
     if (startupCompleteHandler) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -119,22 +119,49 @@ export default class DashToPanelExtension extends Extension {
     ) {
       Main.sessionMode.hasOverview = false
 
-      // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral that
-      // previously delayed the startup animation until after extensions
-      // had loaded. As a result, _startupAnimationSession() may read
-      // Main.sessionMode.hasOverview before our synchronous assignment
-      // above takes effect (the animation chain and extension-enable
-      // chain are concurrent promises, with no guaranteed order).
+      // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral in
+      // Layout._loadBackground that previously held _prepareStartupAnimation
+      // until after the extension-enable chain had run. Without it, the
+      // startup-animation chain and the extension-enable chain are
+      // independent promise chains with no guaranteed ordering.
       //
-      // 'startup-prepared' is emitted at the end of
-      // _prepareStartupAnimation, synchronously, BEFORE _startupAnimation
-      // reads hasOverview. Re-asserting the value in this handler closes
-      // the race window. This is harmless on older versions where the
-      // synchronous assignment was already enough.
+      // _doStartupAnimation reads Main.sessionMode.hasOverview twice:
+      //   1. layout.js _prepareStartupAnimation (decides whether to
+      //      pre-scale uiGroup for the grow-out animation)
+      //   2. layout.js _startupAnimationSession (decides whether to call
+      //      Main.overview.runStartupAnimation)
+      //
+      // 'startup-prepared' fires synchronously between those two reads.
+      // The synchronous assignment above often wins both races on faster
+      // hardware, but on slower setups it can lose the first one. The
+      // handler below is a second line of defense for the second read,
+      // and also catches the case where the overview animation has
+      // already started.
+      //
+      // Defensive: disconnect any previous handler before reconnecting,
+      // in case enable() runs again before startup-complete fired.
+      if (startupPreparedHandler) {
+        Main.layoutManager.disconnect(startupPreparedHandler)
+      }
       startupPreparedHandler = Main.layoutManager.connect(
         'startup-prepared',
         () => {
           Main.sessionMode.hasOverview = false
+
+          // If we lost the first race and Overview.runStartupAnimation
+          // is already in flight, request a hide now. The shell's own
+          // bail-out path in OverviewControls.runStartupAnimation
+          // (overview.js, gnome-shell 50: "Overview got hidden during
+          // startup animation") will short-circuit cleanly when it sees
+          // _shownState != SHOWING after its inner await resolves. This
+          // is preferable to mutating _stateAdjustment / _shown / etc.
+          // directly, which couples us to private overview internals.
+          if (
+            Config.PACKAGE_VERSION >= '50' &&
+            (Main.overview.visible || Main.overview._shown)
+          ) {
+            Main.overview.hide()
+          }
         },
       )
 
@@ -142,30 +169,6 @@ export default class DashToPanelExtension extends Extension {
         'startup-complete',
         () => {
           Main.sessionMode.hasOverview = this._realHasOverview
-
-          // Defensive fallback: if the overview did get shown despite
-          // our efforts (e.g. _startupAnimation already read hasOverview
-          // as true before we could intervene), force it closed. We use
-          // the controls' state adjustment to skip the hide animation
-          // and avoid a visible flash. See dash-to-dock for the same
-          // technique against the same race.
-          if (Config.PACKAGE_VERSION >= '50' && Main.overview.visible) {
-            try {
-              const controls = Main.overview._overview?.controls
-              if (controls?._stateAdjustment) {
-                // 0 == OverviewControls.ControlsState.HIDDEN
-                controls._stateAdjustment.value = 0
-              }
-              Main.overview._shown = false
-              Main.overview._visible = false
-              Main.overview._visibleTarget = false
-              Main.layoutManager.hideOverview()
-            } catch (e) {
-              // Last resort: animated hide, which produces the visible
-              // flash but is better than a stuck overview.
-              Main.overview.hide()
-            }
-          }
         },
       )
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -134,9 +134,7 @@ export default class DashToPanelExtension extends Extension {
       // 'startup-prepared' fires synchronously between those two reads.
       // The synchronous assignment above often wins both races on faster
       // hardware, but on slower setups it can lose the first one. The
-      // handler below is a second line of defense for the second read,
-      // and also catches the case where the overview animation has
-      // already started.
+      // handler below is a second line of defense for the second read.
       //
       // Defensive: disconnect any previous handler before reconnecting,
       // in case enable() runs again before startup-complete fired.
@@ -147,21 +145,6 @@ export default class DashToPanelExtension extends Extension {
         'startup-prepared',
         () => {
           Main.sessionMode.hasOverview = false
-
-          // If we lost the first race and Overview.runStartupAnimation
-          // is already in flight, request a hide now. The shell's own
-          // bail-out path in OverviewControls.runStartupAnimation
-          // (overview.js, gnome-shell 50: "Overview got hidden during
-          // startup animation") will short-circuit cleanly when it sees
-          // _shownState != SHOWING after its inner await resolves. This
-          // is preferable to mutating _stateAdjustment / _shown / etc.
-          // directly, which couples us to private overview internals.
-          if (
-            Config.PACKAGE_VERSION >= '50' &&
-            (Main.overview.visible || Main.overview._shown)
-          ) {
-            Main.overview.hide()
-          }
         },
       )
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -38,7 +38,6 @@ const UBUNTU_DOCK_UUID = 'ubuntu-dock@ubuntu.com'
 
 let panelManager
 let startupCompleteHandler
-let originalPrepareStartupAnimation
 let ubuntuDockDelayId = 0
 
 export let DTP_EXTENSION = null
@@ -55,40 +54,6 @@ export default class DashToPanelExtension extends Extension {
     super(metadata)
 
     this._realHasOverview = Main.sessionMode.hasOverview
-
-    // Install the startup-overview override as early as possible.
-    // GNOME 50's _doStartupAnimation runs concurrently with extension
-    // load; if we wait until enable() (which has awaits before any of
-    // its real work), _prepareStartupAnimation may already have fired
-    // and the overview will be visible at login.
-    //
-    // The constructor runs synchronously the moment GNOME Shell loads
-    // the extension module, before any await yields control back to
-    // _doStartupAnimation. Doing it here is the earliest hook we get.
-    if (
-      Config.PACKAGE_VERSION >= '50' &&
-      Main.layoutManager._startingUp &&
-      this.getSettings('org.gnome.shell.extensions.dash-to-panel').get_boolean(
-        'hide-overview-on-startup',
-      )
-    ) {
-      Main.sessionMode.hasOverview = false
-
-      if (
-        !originalPrepareStartupAnimation &&
-        typeof Main.layoutManager._prepareStartupAnimation === 'function'
-      ) {
-        originalPrepareStartupAnimation =
-          Main.layoutManager._prepareStartupAnimation
-        Main.layoutManager._prepareStartupAnimation = function (...args) {
-          Main.sessionMode.hasOverview = false
-          Main.layoutManager._prepareStartupAnimation =
-            originalPrepareStartupAnimation
-          originalPrepareStartupAnimation = null
-          return Main.layoutManager._prepareStartupAnimation.apply(this, args)
-        }
-      }
-    }
 
     //create an object that persists until gnome-shell is restarted, even if the extension is disabled
     PERSISTENTSTORAGE = {}
@@ -147,20 +112,35 @@ export default class DashToPanelExtension extends Extension {
       'hide-overview-on-startup',
     )
 
-    if (
-      SETTINGS.get_boolean('hide-overview-on-startup') &&
-      Main.layoutManager._startingUp
-    ) {
-      // Restore hasOverview to its real value once startup completes.
-      // (The wrapper installed in the constructor handles forcing
-      // hasOverview=false during _prepareStartupAnimation; this handler
-      // just undoes our temporary override afterwards.)
-      startupCompleteHandler = Main.layoutManager.connect(
-        'startup-complete',
-        () => {
-          Main.sessionMode.hasOverview = this._realHasOverview
-        },
-      )
+    if (SETTINGS.get_boolean('hide-overview-on-startup')) {
+      Main.sessionMode.hasOverview = false
+
+      // GNOME 50 changed extension load timing - on at least some
+      // hardware, dash-to-panel's enable() runs after the shell startup
+      // animation has fully completed (Main.layoutManager._startingUp
+      // is already false and Main.overview._shownState is already
+      // SHOWN). The previous gate on _startingUp meant this branch did
+      // nothing in that case. Drop the gate and act on actual state:
+      // if the overview is showing when we load, hide it.
+      if (Main.layoutManager._startingUp) {
+        // Still in startup - hide on completion as before. The shell's
+        // _startupAnimationComplete fires startup-complete after the
+        // cover pane is destroyed, so a normal hide() runs cleanly.
+        startupCompleteHandler = Main.layoutManager.connect(
+          'startup-complete',
+          () => {
+            Main.sessionMode.hasOverview = this._realHasOverview
+            if (Config.PACKAGE_VERSION >= '50') Main.overview.hide()
+          },
+        )
+      } else {
+        // Startup is already done. Restore hasOverview and hide if
+        // currently shown.
+        Main.sessionMode.hasOverview = this._realHasOverview
+        if (Main.overview.visible || Main.overview._shown) {
+          Main.overview.hide()
+        }
+      }
     }
 
     this.enableGlobalStyles()
@@ -209,14 +189,6 @@ export default class DashToPanelExtension extends Extension {
     this.disableGlobalStyles()
 
     AppIcons.resetRecentlyClickedApp()
-
-    // Restore the wrapper if _prepareStartupAnimation never ran (i.e.
-    // extension disabled before login finished, unusual but possible).
-    if (originalPrepareStartupAnimation) {
-      Main.layoutManager._prepareStartupAnimation =
-        originalPrepareStartupAnimation
-      originalPrepareStartupAnimation = null
-    }
 
     if (startupCompleteHandler) {
       Main.layoutManager.disconnect(startupCompleteHandler)

--- a/src/extension.js
+++ b/src/extension.js
@@ -56,6 +56,40 @@ export default class DashToPanelExtension extends Extension {
 
     this._realHasOverview = Main.sessionMode.hasOverview
 
+    // Install the startup-overview override as early as possible.
+    // GNOME 50's _doStartupAnimation runs concurrently with extension
+    // load; if we wait until enable() (which has awaits before any of
+    // its real work), _prepareStartupAnimation may already have fired
+    // and the overview will be visible at login.
+    //
+    // The constructor runs synchronously the moment GNOME Shell loads
+    // the extension module, before any await yields control back to
+    // _doStartupAnimation. Doing it here is the earliest hook we get.
+    if (
+      Config.PACKAGE_VERSION >= '50' &&
+      Main.layoutManager._startingUp &&
+      this.getSettings('org.gnome.shell.extensions.dash-to-panel').get_boolean(
+        'hide-overview-on-startup',
+      )
+    ) {
+      Main.sessionMode.hasOverview = false
+
+      if (
+        !originalPrepareStartupAnimation &&
+        typeof Main.layoutManager._prepareStartupAnimation === 'function'
+      ) {
+        originalPrepareStartupAnimation =
+          Main.layoutManager._prepareStartupAnimation
+        Main.layoutManager._prepareStartupAnimation = function (...args) {
+          Main.sessionMode.hasOverview = false
+          Main.layoutManager._prepareStartupAnimation =
+            originalPrepareStartupAnimation
+          originalPrepareStartupAnimation = null
+          return Main.layoutManager._prepareStartupAnimation.apply(this, args)
+        }
+      }
+    }
+
     //create an object that persists until gnome-shell is restarted, even if the extension is disabled
     PERSISTENTSTORAGE = {}
   }
@@ -117,36 +151,10 @@ export default class DashToPanelExtension extends Extension {
       SETTINGS.get_boolean('hide-overview-on-startup') &&
       Main.layoutManager._startingUp
     ) {
-      Main.sessionMode.hasOverview = false
-
-      // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral in
-      // Layout._loadBackground that previously held _prepareStartupAnimation
-      // until the extension-enable chain had run. _doStartupAnimation now
-      // reads Main.sessionMode.hasOverview at two awaits with no ordering
-      // guarantee against extension init - first in _prepareStartupAnimation
-      // (decides uiGroup pre-scale), then in _startupAnimationSession
-      // (decides the animation branch).
-      //
-      // Wrapping _prepareStartupAnimation lets us re-assert hasOverview
-      // synchronously, before either read happens. The wrapper restores
-      // itself on first call so we don't keep monkey-patching shell
-      // internals longer than necessary.
-      if (
-        Config.PACKAGE_VERSION >= '50' &&
-        !originalPrepareStartupAnimation &&
-        typeof Main.layoutManager._prepareStartupAnimation === 'function'
-      ) {
-        originalPrepareStartupAnimation =
-          Main.layoutManager._prepareStartupAnimation
-        Main.layoutManager._prepareStartupAnimation = function (...args) {
-          Main.sessionMode.hasOverview = false
-          Main.layoutManager._prepareStartupAnimation =
-            originalPrepareStartupAnimation
-          originalPrepareStartupAnimation = null
-          return Main.layoutManager._prepareStartupAnimation.apply(this, args)
-        }
-      }
-
+      // Restore hasOverview to its real value once startup completes.
+      // (The wrapper installed in the constructor handles forcing
+      // hasOverview=false during _prepareStartupAnimation; this handler
+      // just undoes our temporary override afterwards.)
       startupCompleteHandler = Main.layoutManager.connect(
         'startup-complete',
         () => {

--- a/src/extension.js
+++ b/src/extension.js
@@ -38,6 +38,7 @@ const UBUNTU_DOCK_UUID = 'ubuntu-dock@ubuntu.com'
 
 let panelManager
 let startupCompleteHandler
+let startupPreparedHandler
 let ubuntuDockDelayId = 0
 
 export let DTP_EXTENSION = null
@@ -117,15 +118,54 @@ export default class DashToPanelExtension extends Extension {
       Main.layoutManager._startingUp
     ) {
       Main.sessionMode.hasOverview = false
+
+      // GNOME 50 removed the GLib.idle_add(PRIORITY_LOW) deferral that
+      // previously delayed the startup animation until after extensions
+      // had loaded. As a result, _startupAnimationSession() may read
+      // Main.sessionMode.hasOverview before our synchronous assignment
+      // above takes effect (the animation chain and extension-enable
+      // chain are concurrent promises, with no guaranteed order).
+      //
+      // 'startup-prepared' is emitted at the end of
+      // _prepareStartupAnimation, synchronously, BEFORE _startupAnimation
+      // reads hasOverview. Re-asserting the value in this handler closes
+      // the race window. This is harmless on older versions where the
+      // synchronous assignment was already enough.
+      startupPreparedHandler = Main.layoutManager.connect(
+        'startup-prepared',
+        () => {
+          Main.sessionMode.hasOverview = false
+        },
+      )
+
       startupCompleteHandler = Main.layoutManager.connect(
         'startup-complete',
         () => {
           Main.sessionMode.hasOverview = this._realHasOverview
 
-          // the extension initialization timing changed in g-s version 50 and the startup animation
-          // is already running when the extension init code is executed. Since there is no way to
-          // prevent the animation from running, hide the overview when it completes
-          if (Config.PACKAGE_VERSION >= '50') Main.overview.hide()
+          // Defensive fallback: if the overview did get shown despite
+          // our efforts (e.g. _startupAnimation already read hasOverview
+          // as true before we could intervene), force it closed. We use
+          // the controls' state adjustment to skip the hide animation
+          // and avoid a visible flash. See dash-to-dock for the same
+          // technique against the same race.
+          if (Config.PACKAGE_VERSION >= '50' && Main.overview.visible) {
+            try {
+              const controls = Main.overview._overview?.controls
+              if (controls?._stateAdjustment) {
+                // 0 == OverviewControls.ControlsState.HIDDEN
+                controls._stateAdjustment.value = 0
+              }
+              Main.overview._shown = false
+              Main.overview._visible = false
+              Main.overview._visibleTarget = false
+              Main.layoutManager.hideOverview()
+            } catch (e) {
+              // Last resort: animated hide, which produces the visible
+              // flash but is better than a stuck overview.
+              Main.overview.hide()
+            }
+          }
         },
       )
     }
@@ -176,6 +216,11 @@ export default class DashToPanelExtension extends Extension {
     this.disableGlobalStyles()
 
     AppIcons.resetRecentlyClickedApp()
+
+    if (startupPreparedHandler) {
+      Main.layoutManager.disconnect(startupPreparedHandler)
+      startupPreparedHandler = null
+    }
 
     if (startupCompleteHandler) {
       Main.layoutManager.disconnect(startupCompleteHandler)

--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -794,17 +794,31 @@ export const Taskbar = class extends EventEmitter {
     item.setChild(appIcon)
     appIcon._dashItemContainer = item
 
+    // T1 is shared across icons, so it must be cancelled when the icon that
+    // scheduled it is destroyed - otherwise it fires up to 100ms later on a
+    // disposed actor. Ownership is tracked so one icon cannot cancel another's.
+    appIcon.connect('destroy', () => {
+      if (this._hoverScrollIcon == appIcon) {
+        this._timeoutsHandler.remove(T1)
+        this._hoverScrollIcon = null
+      }
+    })
+
     appIcon.connect('notify::hover', () => {
       if (appIcon.hover) {
+        this._hoverScrollIcon = appIcon
         this._timeoutsHandler.add([
           T1,
           100,
-          () =>
+          () => {
+            if (this._hoverScrollIcon != appIcon) return
+            this._hoverScrollIcon = null
             Utils.ensureActorVisibleInScrollView(
               this._scrollView,
               appIcon,
               this._scrollView._dtpFadeSize,
-            ),
+            )
+          },
         ])
 
         if (!appIcon.isDragged && iconAnimationSettings.type == 'SIMPLE')
@@ -1562,6 +1576,16 @@ export const TaskbarItemContainer = GObject.registerClass(
     _init() {
       super._init()
       this.x_expand = this.y_expand = false
+
+      // The raised clone's adjustment and taskbarBox handlers are disconnected
+      // only from the clone's own destroy handler (see _createRaisedClone).
+      // animateOutAndDestroy() destroys the clone, but plain destroy() does not,
+      // and resetAppIcons() and the pre-_shownInitially path both use destroy().
+      // The clone lives in Main.uiGroup, so it would survive its container and
+      // keep dereferencing a disposed actor on every panel allocation.
+      this.connect('destroy', () => {
+        if (this._raisedClone) this._raisedClone.destroy()
+      })
     }
 
     vfunc_allocate(box) {


### PR DESCRIPTION
Two sources of `has been already disposed` warnings during panel allocation, seen on GNOME Shell 50 with panels on two monitors.

**Orphaned raised clone.** The clone's adjustment and taskbarBox handlers are disconnected only from the clone's own destroy handler. `animateOutAndDestroy()` destroys the clone, but plain `destroy()` does not, and both `resetAppIcons()` and the pre-`_shownInitially` path use `destroy()`. The clone lives in `Main.uiGroup`, so it outlives its container and keeps dereferencing a disposed actor on every allocation.

**Shared hover timeout.** `T1` is shared across icons, so it must be cancelled when the icon that scheduled it is destroyed, otherwise it fires up to 100ms later on a disposed actor. Ownership is tracked so one icon cannot cancel another's.

Related to the diagnosis in #2469, but these are different paths.
