### PR TITLE
feat: hide chosen apps from the panel

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -765,6 +765,11 @@
       </default>
       <summary>User defined context menu entries</summary>
     </key>
+    <key type="s" name="hide-from-panel-apps">
+      <default>'[]'</default>
+      <summary>Apps whose windows never appear in the panel</summary>
+      <description>JSON array of desktop file ids. Windows belonging to these apps are not shown in the taskbar. A pinned favourite for such an app still appears and still launches.</description>
+    </key>
     <key type="i" name="scroll-panel-delay">
       <default>0</default>
       <summary>Delay between panel mouse scroll events</summary>

--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -1851,11 +1851,48 @@ export function closeAllWindows(app, monitor) {
     windows[i].delete(global.get_current_time())
 }
 
+// The parsed set is cached against the RAW setting string rather than
+// invalidated by a signal. A module-level cache outlives the extension - GNOME
+// keeps imported modules for the life of the shell process, while
+// Taskbar.destroy() disconnects the setting handlers - so a list edited while
+// the extension is disabled would otherwise be read stale forever.
+let hiddenAppsRaw = null
+let hiddenApps = new Set()
+
+export function isHiddenFromPanel(app) {
+  let raw = SETTINGS.get_string('hide-from-panel-apps')
+
+  if (raw !== hiddenAppsRaw) {
+    hiddenAppsRaw = raw
+
+    try {
+      hiddenApps = new Set(JSON.parse(raw))
+    } catch {
+      // A hand-edited value must not take the panel down with it.
+      hiddenApps = new Set()
+    }
+  }
+
+  // An unresolved window has no stable identity, so it can never have been
+  // added to the list. Keeping it is the safe direction: filtering it would
+  // hide a window the user never excluded.
+  return !!app && hiddenApps.has(app.get_id())
+}
+
 // Filter out unnecessary windows, for instance
 // nautilus desktop window.
 export function getInterestingWindows(app, monitor, isolateMonitors) {
+  let hidden = app ? isHiddenFromPanel(app) : null
+
   let windows = (app ? app.get_windows() : Utils.getAllMetaWindows()).filter(
-    (w) => !w.skip_taskbar,
+    (w) =>
+      !w.skip_taskbar &&
+      // `app` is null on the split-app path (taskbar.js), where each window
+      // must be resolved individually. get_window_app() can itself return
+      // null - guarded inside isHiddenFromPanel.
+      !(hidden === null
+        ? isHiddenFromPanel(tracker.get_window_app(w))
+        : hidden),
   )
 
   // When using workspace or monitor isolation, we filter out windows

--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -842,7 +842,7 @@ export const TaskbarAppIcon = GObject.registerClass(
     }
 
     _checkIfFocusedApp() {
-      return tracker.focus_app == this.app
+      return !isHiddenFromPanel(this.app) && tracker.focus_app == this.app
     }
 
     _checkIfMonitorHasFocus() {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -3081,6 +3081,139 @@ const Preferences = class {
 
     createContextMenuEntries()
 
+    // Every callback below is an arrow function, so `this` stays the prefs
+    // object and `this._settings` resolves. prefs.js has no SETTINGS global.
+    let hideAppsRows = []
+    let hideAppsGroup = this._builder.get_object('hide_apps_group')
+    let hideAppsAddButton = this._builder.get_object('hide_apps_add_button')
+    let hiddenApps = []
+
+    try {
+      hiddenApps = JSON.parse(this._settings.get_string('hide-from-panel-apps'))
+    } catch {
+      hiddenApps = []
+    }
+
+    let saveHiddenApps = () => {
+      this._settings.set_string(
+        'hide-from-panel-apps',
+        JSON.stringify(hiddenApps),
+      )
+      createHiddenAppRows()
+    }
+
+    // A stored id whose app has been uninstalled still gets a row, showing the
+    // raw id and a fallback icon, so it can be seen and removed rather than
+    // silently occupying the list.
+    let createHiddenAppRows = () => {
+      hideAppsRows.forEach((r) => hideAppsGroup.remove(r))
+      hideAppsRows = []
+
+      hiddenApps.forEach((id, i) => {
+        // GioUnix, not Gio - Gio.DesktopAppInfo is deprecated and prefs.js
+        // already imports GioUnix.
+        let info = GioUnix.DesktopAppInfo.new(id)
+        let row = new Adw.ActionRow({
+          title: info ? info.get_display_name() : id,
+          subtitle: info ? id : _('Not installed'),
+        })
+
+        row.add_prefix(
+          new Gtk.Image({
+            gicon: info ? info.get_icon() : null,
+            icon_name: info ? null : 'application-x-executable-symbolic',
+            pixel_size: 32,
+          }),
+        )
+
+        row.add_suffix(
+          createButton('user-trash-symbolic', _('Remove'), () => {
+            hiddenApps.splice(i, 1)
+            saveHiddenApps()
+          }),
+        )
+
+        hideAppsGroup.add(row)
+        hideAppsRows.push(row)
+      })
+    }
+
+    hideAppsAddButton.connect('clicked', () => {
+      // Only apps the user could see in the app grid, minus those already
+      // listed, so the same app cannot be added twice.
+      let apps = Gio.AppInfo.get_all()
+        .filter((a) => a.should_show() && hiddenApps.indexOf(a.get_id()) < 0)
+        .sort((a, b) =>
+          a.get_display_name().localeCompare(b.get_display_name()),
+        )
+
+      if (!apps.length) return
+
+      let model = new Gio.ListStore({ item_type: Gio.AppInfo })
+      apps.forEach((a) => model.append(a))
+
+      // One factory renders BOTH the selected value and the popup rows.
+      // list-factory is deliberately left unset so the two cannot drift.
+      let factory = new Gtk.SignalListItemFactory()
+
+      factory.connect('setup', (f, item) => {
+        let box = new Gtk.Box({ spacing: 8 })
+
+        box.append(new Gtk.Image({ pixel_size: 16 }))
+        box.append(new Gtk.Label({ xalign: 0 }))
+        item.set_child(box)
+      })
+
+      factory.connect('bind', (f, item) => {
+        let app = item.get_item()
+        let box = item.get_child()
+
+        box.get_first_child().set_from_gicon(app.get_icon())
+        box.get_last_child().set_label(app.get_display_name())
+      })
+
+      let combo = new Adw.ComboRow({
+        title: _('Add app'),
+        model,
+        factory,
+        // enable-search alone has no search key when the model holds objects
+        // rather than strings; the expression is what supplies it.
+        expression: Gtk.ClosureExpression.new(
+          GObject.TYPE_STRING,
+          (app) => app.get_display_name(),
+          null,
+        ),
+        enable_search: true,
+      })
+
+      const ADD_RESPONSE = 'add'
+      let dialog = new Adw.AlertDialog({
+        heading: _('Hide an app from the panel'),
+      })
+      let list = new Gtk.ListBox({ selection_mode: Gtk.SelectionMode.NONE })
+
+      list.add_css_class('boxed-list')
+      list.append(combo)
+      dialog.set_extra_child(list)
+      dialog.add_response('cancel', _('Cancel'))
+      dialog.add_response(ADD_RESPONSE, _('Add'))
+      dialog.set_response_appearance(
+        ADD_RESPONSE,
+        Adw.ResponseAppearance.SUGGESTED,
+      )
+
+      dialog.connect('response', (d, response) => {
+        if (response != ADD_RESPONSE) return
+
+        hiddenApps.push(model.get_item(combo.get_selected()).get_id())
+        saveHiddenApps()
+      })
+
+      dialog.present(hideAppsAddButton.get_root())
+    })
+
+    createHiddenAppRows()
+
     // Create dialog for panel scroll options
     this._builder
       .get_object('scroll_panel_options_button')

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -3094,6 +3094,8 @@ const Preferences = class {
       hiddenApps = []
     }
 
+    if (!Array.isArray(hiddenApps)) hiddenApps = []
+
     let saveHiddenApps = () => {
       this._settings.set_string(
         'hide-from-panel-apps',
@@ -3118,13 +3120,12 @@ const Preferences = class {
           subtitle: info ? id : _('Not installed'),
         })
 
-        row.add_prefix(
-          new Gtk.Image({
-            gicon: info ? info.get_icon() : null,
-            icon_name: info ? null : 'application-x-executable-symbolic',
-            pixel_size: 32,
-          }),
-        )
+        let image = new Gtk.Image({ pixel_size: 32 })
+
+        if (info) image.set_from_gicon(info.get_icon())
+        else image.set_from_icon_name('application-x-executable-symbolic')
+
+        row.add_prefix(image)
 
         row.add_suffix(
           createButton('user-trash-symbolic', _('Remove'), () => {
@@ -3167,8 +3168,14 @@ const Preferences = class {
       factory.connect('bind', (f, item) => {
         let app = item.get_item()
         let box = item.get_child()
+        let icon = app.get_icon()
 
-        box.get_first_child().set_from_gicon(app.get_icon())
+        if (icon) box.get_first_child().set_from_gicon(icon)
+        else
+          box
+            .get_first_child()
+            .set_from_icon_name('application-x-executable-symbolic')
+
         box.get_last_child().set_label(app.get_display_name())
       })
 

--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -403,7 +403,7 @@ export const Taskbar = class extends EventEmitter {
           this._connectWorkspaceSignals()
         },
       ],
-      [SETTINGS, 'changed::hide-from-panel-apps', () => this._redisplay()],
+      [SETTINGS, 'changed::hide-from-panel-apps', () => this.resetAppIcons()],
       [
         SETTINGS,
         [

--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -403,6 +403,7 @@ export const Taskbar = class extends EventEmitter {
           this._connectWorkspaceSignals()
         },
       ],
+      [SETTINGS, 'changed::hide-from-panel-apps', () => this._redisplay()],
       [
         SETTINGS,
         [

--- a/ui/SettingsFineTune.ui
+++ b/ui/SettingsFineTune.ui
@@ -198,5 +198,29 @@
         </child>
       </object>
     </child>
+    <child>
+      <object class="AdwPreferencesGroup" id="hide_apps_group">
+        <property name="title" translatable="yes">Hide apps from the panel</property>
+        <property name="description" translatable="yes">Windows of these apps never appear in the taskbar. A pinned favourite still appears and still launches.</property>
+        <child>
+          <object class="GtkButton" id="hide_apps_add_button">
+            <property name="halign">center</property>
+            <property name="margin-top">10</property>
+            <property name="receives-default">True</property>
+            <property name="valign">center</property>
+            <property name="width-request">100</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">list-add-symbolic</property>
+                <property name="tooltip-text" translatable="yes">Add app</property>
+              </object>
+            </child>
+            <style>
+              <class name="circular"/>
+            </style>
+          </object>
+        </child>
+      </object>
+    </child>
   </object>
 </interface>


### PR DESCRIPTION
`MetaWindow.skip-taskbar` is read-only and xdg-shell has no client request for it, so a Wayland app cannot keep itself out of the taskbar. Popup-style apps (an emoji picker summoned by a shortcut, for instance) therefore occupy a taskbar slot with no way to opt out.

This adds a `hide-from-panel-apps` setting, a JSON array of desktop file ids, and a group in Fine-Tune to manage it with a searchable app picker.

A pinned favourite for a hidden app still appears and still launches. Only the running-window icon is suppressed.

Three things worth flagging in review:

- `getInterestingWindows()` is called with `app === null` on the split-app path, so windows are resolved individually via `get_window_app()`, which can itself return null. Unresolved windows are kept rather than filtered.
- The parsed set is cached against the raw setting string instead of being invalidated by a signal. A module-level cache outlives the extension across disable/enable, while `Taskbar.destroy()` disconnects the handlers.
- The settings handler calls `resetAppIcons()` rather than `_redisplay()`, matching `isolate-workspaces`. `_redisplay()` alone leaves a surviving pinned icon with a stale window count, so its running dots stay lit.

Tested manually on GNOME Shell 50.3 / Wayland with panels on two monitors: exclusion, pinned favourite unaffected, live add and remove, no duplicates in the picker, split-app mode, and an uninstalled desktop id. There is no automated test suite in this repository.
