### PR TITLE
Fix Looking Glass not opening without a panel on the primary monitor

### DIFF
--- a/src/panelManager.js
+++ b/src/panelManager.js
@@ -1111,7 +1111,7 @@ function _newLookingGlassResize() {
     (p) => p.monitor == Main.layoutManager.primaryMonitor,
   )
   let topOffset =
-    primaryMonitorPanel.geom.position == St.Side.TOP
+    primaryMonitorPanel && primaryMonitorPanel.geom.position == St.Side.TOP
       ? primaryMonitorPanel.geom.outerSize +
         (SETTINGS.get_boolean('stockgs-keep-top-panel')
           ? Main.layoutManager.panelBox.height


### PR DESCRIPTION
### Problem

With Dash to Panel enabled, pressing Alt+F2 and entering `lg` does nothing at all. The run dialog stays open and Looking Glass never appears.

The log shows:

```
JS ERROR: TypeError: can't access property "geom", primaryMonitorPanel is undefined
_newLookingGlassResize@file:///home/user/.local/share/gnome-shell/extensions/dash-to-panel@jderose9.github.com/panelManager.js:1112:5
_init@resource:///org/gnome/shell/ui/lookingGlass.js:1470:14
LookingGlass@resource:///org/gnome/shell/ui/lookingGlass.js:1320:1
createLookingGlass@resource:///org/gnome/shell/ui/main.js:888:24
lg@resource:///org/gnome/shell/ui/runDialog.js:46:30
_run@resource:///org/gnome/shell/ui/runDialog.js:215:13
```

### Cause

`_newLookingGlassResize()` looks up the panel of the primary monitor and dereferences the result without checking it:

```js
let primaryMonitorPanel = Utils.find(
  global.dashToPanel.panels,
  (p) => p.monitor == Main.layoutManager.primaryMonitor,
)
let topOffset =
  primaryMonitorPanel.geom.position == St.Side.TOP
```

With `multi-monitors` disabled there is exactly one panel. If that panel sits on a monitor other than the one GNOME considers primary, the lookup cannot match anything, `primaryMonitorPanel` is undefined and the next line throws.
`LookingGlass._init()` is aborted, so the window is never created.

### Fix

Guard the lookup and let the undefined case fall through to the existing `Panel.GS_PANEL_SIZE` branch. That branch already covers the situation where no panel occupies the top of the primary monitor, which is exactly what a missing panel means, so the change adds no new behaviour of its own.

### Steps to reproduce

1. Two or more monitors.
2. Dash to Panel with `multi-monitors` off, and the panel placed on a monitor that is not the primary one.
3. Press Alt+F2, enter `lg`, press Enter.

Expected: Looking Glass opens. Actual: nothing happens, and the log contains the TypeError above.

### Confirmed with Dash to Panel as the only enabled extension

Every other extension was disabled, the session was restarted, and the extension files were left unmodified. The same TypeError appears.

This is worth stating explicitly because #2406 described a related symptom and was closed on the assumption that Just Perfection was responsible. The failure above needs no other extension.

### Environment

- Ubuntu 26.04, GNOME Shell 50.1, Wayland
- Dash to Panel v73, installed from extensions.gnome.org
- Current `master` (1c0c1f1) contains the same unguarded line
- Three 1920x1080 monitors side by side, the middle one is the GNOME primary
  display, the panel is on the rightmost one

Monitor layout, the middle display is primary and the panel is on display 1 on the right:
<img width="1030" height="690" alt="dtp-pr-monitor-layout" src="https://github.com/user-attachments/assets/7f4132ef-8e67-42e9-b17a-339f327fd26a" />

### Related

- #2406, same symptom, closed as an assumed Just Perfection interaction
- #1084, Looking Glass positioning with a top panel, fixed back then