### PR TITLE
Add Resources to context menu

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-panel.gschema.xml
@@ -754,6 +754,10 @@
             "cmd": "gnome-system-monitor"
           },
           {
+            "title": "Resources",
+            "cmd": "resources"
+          },
+          {
             "title": "Files",
             "cmd": "nautilus"
           },


### PR DESCRIPTION
Gnome will be switching to Resources as new "system monitor" at some point and it is already the default for Ubuntu 26.04. Add a default Resources entry to the context menu to reflect that change. It will not be shown for systems that do not have it installed.