### PR TITLE
Enable shell-version 51

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "uuid": "dash-to-panel@jderose9.github.com",
   "name": "Dash to Panel",
   "description": "An icon taskbar for the Gnome Shell. This extension moves the dash into the gnome main panel so that the application launchers and system tray are combined into a single panel, similar to that found in KDE Plasma and Windows 7+. A separate dock is no longer needed for easy access to running and favorited applications.\n\nFor a more traditional experience, you may also want to use Tweak Tool to enable Windows > Titlebar Buttons > Minimize & Maximize.\n\nFor the best support, please report any issues on Github. Dash-to-panel is developed and maintained by @jderose9 and @charlesg99.",
-  "shell-version": [ "46", "47", "48", "49", "50" ],
+  "shell-version": [ "46", "47", "48", "49", "50", "51" ],
   "url": "https://github.com/home-sweet-gnome/dash-to-panel",
   "gettext-domain": "dash-to-panel",
   "version": 9999,


### PR DESCRIPTION
Enable gnome-shell 51, I have tested it on Ubuntu 26.10 development with Gnome 51 alpha. Everything seems to work fine so far, did not test every single setting though.