### PR TITLE
Fix missing calendar events in secondary monitor date menu

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -374,6 +374,20 @@ export const Panel = GObject.registerClass(
         [Main.layoutManager, 'startup-complete', () => this._resetGeometry()],
       )
 
+      if (this.isStandalone && this.statusArea.dateMenu) {
+        // A cloned DateMenuButton constructed while org.gnome.Shell.CalendarServer
+        // isn't responsive yet (e.g. at login) gets an event source whose
+        // HasCalendars property never loads, so its events section stays hidden.
+        // The primary panel reuses gnome-shell's own working date menu, so repair
+        // the clone's event source the next time the menu opens, by which point
+        // the service is available.
+        this._signalsHandler.add([
+          this.statusArea.dateMenu.menu,
+          'open-state-changed',
+          (menu, isOpen) => isOpen && this._repairDateMenuEventSource(),
+        ])
+      }
+
       this._bindSettingsChanges()
 
       this.panelStyle.enable(this)
@@ -726,6 +740,22 @@ export const Panel = GObject.registerClass(
       }
 
       return PERSISTENTSTORAGE[propName].pop()
+    }
+
+    _repairDateMenuEventSource() {
+      let dateMenu = this.statusArea.dateMenu
+      let primarySource = Main.panel.statusArea.dateMenu._eventSource
+
+      // Only recreate when the primary date menu has calendars but this clone
+      // doesn't: that's the stuck-proxy state. Once recreated (with the service
+      // now up) hasCalendars becomes true, so this turns into a no-op.
+      if (
+        dateMenu._eventSource &&
+        primarySource &&
+        primarySource.hasCalendars &&
+        !dateMenu._eventSource.hasCalendars
+      )
+        dateMenu._setEventSource(dateMenu._getEventSource())
     }
 
     _adjustForOverview() {


### PR DESCRIPTION
The date menu on a secondary (non-primary) panel could permanently show no events: the "Today" events section was absent entirely, while the date menu on the primary monitor listed events normally.

dash-to-panel gives each secondary panel its own DateMenuButton, and every DateMenuButton builds its own DBusEventSource proxy to org.gnome.Shell.CalendarServer. When a clone is constructed while the calendar server is not yet responsive -- typically right after login, while the extension is enabling -- the proxy's init_async times out. GNOME Shell's DBusEventSource installs its signals but never re-fetches the HasCalendars property afterwards, so hasCalendars stays unset and EventsSection._sync() keeps the events section hidden forever.

GNOME Shell never hits this: it has a single date menu, on the primary panel, created at shell startup, and does not clone it onto other monitors.

Repair the clone's event source the next time its menu is opened, by which point the calendar server is available. The recreation runs only when the primary date menu has calendars but the clone does not -- the stuck state -- so it is a no-op once repaired, and when the user genuinely has no calendars.

gh-2548