### PR TITLE
Fix panel menu height on non-primary monitors

### DIFF
--- a/src/panelManager.js
+++ b/src/panelManager.js
@@ -334,6 +334,11 @@ export const PanelManager = class {
           )
         }
 
+        if (pmb.menu._dtpMaxHeightId) {
+          pmb.menu.disconnect(pmb.menu._dtpMaxHeightId)
+          delete pmb.menu._dtpMaxHeightId
+        }
+
         pmb.menu._boxPointer.sourceActor = pmb.menu._boxPointer._dtpSourceActor
         delete pmb.menu._boxPointer._dtpSourceActor
         pmb.menu._boxPointer._userArrowSide = St.Side.TOP
@@ -746,7 +751,29 @@ export const PanelManager = class {
             },
           )
       }
+
+      // PanelMenu.Button._onOpenStateChanged sizes the menu from the primary
+      // monitor's work area, which is wrong when this panel lives on another
+      // monitor. Re-apply max-height after the upstream handler, using this
+      // panel's own monitor.
+      button.menu._dtpMaxHeightId = button.menu.connect(
+        'open-state-changed',
+        (menu, isOpen) =>
+          isOpen && this._setPanelMenuMaxHeight(button, monitor),
+      )
     }
+  }
+
+  _setPanelMenuMaxHeight(button, monitor) {
+    let workArea = Main.layoutManager.getWorkAreaForMonitor(monitor.index)
+    let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor
+    let verticalMargins =
+      button.menu.actor.margin_top + button.menu.actor.margin_bottom
+    let maxHeight = Math.round(
+      (workArea.height - verticalMargins) / scaleFactor,
+    )
+
+    button.menu.actor.style = `max-height: ${maxHeight}px;`
   }
 
   _getBoxPointerPreferredHeight(boxPointer, alloc, monitor) {


### PR DESCRIPTION
On a multi-monitor setup dash-to-panel places a panel, and thus a clock/date menu, on every monitor. When such a menu opens from a bottom panel on a non-primary monitor, it is sized using the wrong monitor's work area: a menu on a monitor taller than the primary leaves a gap at the top, and a menu on a monitor shorter than the primary overflows off the top edge of the screen.

The cause is in GNOME Shell itself. PanelMenu.Button._onOpenStateChanged sets the menu's CSS max-height from
getWorkAreaForMonitor(Main.layoutManager.primaryIndex) -- always the primary monitor. That is correct for stock GNOME Shell, which only ever has a single panel, on the primary monitor, and so never opens such a menu anywhere else. It is wrong for dash-to-panel, which clones the panel onto secondary monitors.

Re-apply the max-height after the upstream handler runs, computing it from the work area of the monitor the panel actually lives on. The handler is connected per panel menu and disconnected on disable.

gh-2550