### PR TITLE
Fix taskbar stale window buttons and missing running windows

### DIFF
--- a/src/appIcons.js
+++ b/src/appIcons.js
@@ -1179,8 +1179,14 @@ export const TaskbarAppIcon = GObject.registerClass(
                       modifiers & Clutter.ModifierType.SHIFT_MASK)))
               ) {
                 this.window.minimize()
-              } else {
+              } else if (this.window.get_workspace()) {
                 Main.activateWindow(this.window)
+              } else {
+                // The window this icon references is stale (the window was
+                // closed already): refresh the taskbar so the button is
+                // dropped, and fall back to activating the app normally.
+                this.dtpPanel.taskbar._queueRedisplay()
+                this.app.activate()
               }
           }
         } else {
@@ -1305,7 +1311,10 @@ export const TaskbarAppIcon = GObject.registerClass(
         maybeAnimate()
         this.app.open_new_window(-1)
       } else {
-        let windows = this.window ? [this.window] : this.app.get_windows()
+        let windows =
+          this.window && this.window.get_workspace()
+            ? [this.window]
+            : this.app.get_windows()
 
         if (windows.length) {
           Main.activateWindow(windows[0])
@@ -1718,7 +1727,7 @@ export const TaskbarAppIcon = GObject.registerClass(
           return DND.DragMotionResult.MOVE_DROP
 
         if (this._nWindows == 1 || this.window) {
-          this.window
+          this.window && this.window.get_workspace()
             ? Main.activateWindow(this.window)
             : activateFirstWindow(this.app, this.monitor)
         } else
@@ -1769,15 +1778,18 @@ export function activateAllWindows(app, monitor) {
   // First activate first window so workspace is switched if needed,
   // then activate all other app windows in the current workspace.
   let windows = getInterestingWindows(app, monitor)
-  let w = windows[0]
-  Main.activateWindow(w)
-  let activeWorkspace =
-    Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace_index()
 
   if (windows.length <= 0) return
 
+  let w = windows[0]
+  if (w.get_workspace()) Main.activateWindow(w)
+
+  let activeWorkspace =
+    Utils.DisplayWrapper.getWorkspaceManager().get_active_workspace_index()
+
   for (let i = windows.length - 1; i >= 0; i--) {
-    if (windows[i].get_workspace().index() == activeWorkspace) {
+    let workspace = windows[i].get_workspace()
+    if (workspace && workspace.index() == activeWorkspace) {
       Main.activateWindow(windows[i])
     }
   }
@@ -1785,7 +1797,7 @@ export function activateAllWindows(app, monitor) {
 
 export function activateFirstWindow(app, monitor) {
   let windows = getInterestingWindows(app, monitor)
-  Main.activateWindow(windows[0])
+  if (windows.length) Main.activateWindow(windows[0])
 }
 
 export function cycleThroughWindows(app, reversed, shouldMinimize, monitor) {
@@ -1828,9 +1840,10 @@ export function cycleThroughWindows(app, reversed, shouldMinimize, monitor) {
   }
   let index = recentlyClickedAppIndex % recentlyClickedAppWindows.length
 
-  if (recentlyClickedAppWindows[index] === 'MINIMIZE')
-    minimizeWindow(app, true, monitor)
-  else Main.activateWindow(recentlyClickedAppWindows[index])
+  let target = recentlyClickedAppWindows[index]
+
+  if (target === 'MINIMIZE') minimizeWindow(app, true, monitor)
+  else if (target && target.get_workspace()) Main.activateWindow(target)
 }
 
 export function resetRecentlyClickedApp() {

--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -354,6 +354,11 @@ export const Taskbar = class extends EventEmitter {
         },
       ],
       [this._appSystem, 'app-state-changed', this._queueRedisplay.bind(this)],
+      // The shell's window tracker is the authoritative source for which
+      // windows exist. Redisplay whenever the tracked window set changes so
+      // stale taskbar buttons are dropped and new windows are shown even if
+      // workspace-level window signals are missed.
+      [tracker, 'tracked-windows-changed', () => this._queueRedisplay()],
       [
         AppFavorites.getAppFavorites(),
         'changed',


### PR DESCRIPTION
I occasionally had the issue that application icons would get stuck (closed applications would still have an icon) and at the same time new application icons would not appear in dash-to-panel. Restarting the GNOME session solved the issue, but I have spent some time investigating and came up with this PR which might solve the issue by adding some extra guard code by resyncing the taskbar with the window tracker and adding stale-window guards.


## Technical explanation
The taskbar can keep TaskbarAppIcon buttons for windows that already closed. Those buttons hold stale MetaWindow references whose `get_workspace()` returns `null`; clicking them throws `TypeError: can't access property "index", window.get_workspace() is null` (seen in the shell journal as `activate@appIcons.js:1183`). Meanwhile newly opened windows can fail to appear, so the panel drifts out of sync with the window tracker until the shell is restarted.

Closes #2482
Related to #1544

## Root cause
The taskbar refreshed only from workspace-level `window-added`/`window-removed` and `app-state-changed` signals. These can be missed (e.g. during monitor hotplug or app teardown races), leaving stale buttons and untracked new windows. Several `activateWindow` paths also assume non-empty window lists and non-null workspaces.

## Potential fix
- Redisplay the taskbar whenever `Shell.WindowTracker` emits `tracked-windows-changed` (the authoritative window-set signal), so stale buttons are dropped and new windows appear even if workspace signals are missed.
- Null-guard every `Main.activateWindow()`/`get_workspace()` call site against stale/unmanaged windows, and guard against empty window lists (activateAllWindows called `windows[0]` before its empty check).

I have tested the fix in my own environment:

Arch Linux (btw), GNOME Shell 50.4, Wayland, multi-monitor (dash-to-panel v73 + patch):

- Open/close/rapid-cycle windows: buttons appear/disappear correctly
- Same-app multi-window: grouped correctly
- KVM monitor unplug/replug (mutter `logical_monitor != NULL` asserts fire)
- zero `get_workspace() is null` crashes in journal after fix